### PR TITLE
Avoid stretching the table for filter inputs

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,3 +24,15 @@ body {
   margin-right: 5px;
 }
 
+.column-filter-input {
+  width: 100%;
+}
+
+.column-filter-input[name="id"] {
+  max-width: 7em;
+}
+
+.column-filter-input[name="actualHours"],
+.column-filter-input[name="budgetHours"] {
+  max-width: 8em;
+}


### PR DESCRIPTION
Otherwise, when the window is not wide, the table stretches beyond the page width.

This also explicitly sets a few column widths to keep them from eating up whitespace and making other columns wrap.