### PR TITLE
Toggl description UX

### DIFF
--- a/src/components/Tickets/AddProject.js
+++ b/src/components/Tickets/AddProject.js
@@ -27,6 +27,7 @@ export default class AddProject extends Component {
             type="number"
             value={this.state.projectId}
             className="form-control"
+            placeholder="123"
           />
           <div className="input-group-btn">
             <button type="submit" className="btn btn-primary">Add</button>

--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -72,7 +72,14 @@ class StartTimer extends Component {
               className="btn btn-success"
               type="submit"
             >
-              Start
+              Start Timer
+            </button>
+            <button
+              className="btn btn-link"
+              onClick={this.toggle}
+              type="button"
+            >
+              Cancel
             </button>
           </form>
         </div>

--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -48,18 +48,11 @@ class StartTimer extends Component {
     return (
       <div className={className}>
         <button
-          className="btn btn-default"
-          onClick={e => this.startTimer()} 
-          type="button"
-        >
-          Start
-        </button>
-        <button 
           className="btn btn-default dropdown-toggle"
           onClick={this.toggle}
           type="button"
         >
-          <span className="caret"></span>
+          Start
           <span className="sr-only">Toggle Dropdown</span>
         </button>
         <div className="dropdown-menu">

--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -31,7 +31,7 @@ class StartTimer extends Component {
   toggle() {
     const willExpand = !this.state.expanded;
 
-    this.setState({ 
+    this.setState({
       expanded: willExpand,
     }, () => {
       if (willExpand) {
@@ -41,7 +41,7 @@ class StartTimer extends Component {
   }
 
   render() {
-    const className = classnames('btn-group', { 
+    const className = classnames('btn-group', {
       'open': this.state.expanded,
     });
 

--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -53,7 +53,7 @@ class StartTimer extends Component {
           onClick={this.toggle}
           type="button"
         >
-          Start
+          <span className="glyphicon glyphicon-time"></span>
           <span className="sr-only">Toggle Dropdown</span>
         </button>
         <div className="dropdown-menu toggl-description">

--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -33,6 +33,7 @@ class StartTimer extends Component {
 
     this.setState({
       expanded: willExpand,
+      description: this.props.ticket.summary,
     }, () => {
       if (willExpand) {
         this.input.focus();
@@ -55,18 +56,20 @@ class StartTimer extends Component {
           Start
           <span className="sr-only">Toggle Dropdown</span>
         </button>
-        <div className="dropdown-menu">
+        <div className="dropdown-menu toggl-description">
           <form onSubmit={this.startCustomTimer}>
-            <label htmlFor="description">Description</label>
-            <input 
-              id="description"
-              onChange={e => this.setState({ description: e.target.value })}
-              ref={ref => { this.input = ref }}
-              type="text"
-              value={this.state.description}
-            />
-            <button 
-              className="btn btn-default"
+            <div className="form-group">
+              <label htmlFor="description">Timer Description</label>
+              <textarea
+                id="description"
+                onChange={e => this.setState({ description: e.target.value })}
+                className="form-control"
+                ref={ref => { this.input = ref }}
+                value={this.state.description}
+              />
+            </div>
+            <button
+              className="btn btn-success"
               type="submit"
             >
               Start

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -236,7 +236,7 @@ TicketsTable.defaultProps = {
     {
       property: 'resources',
       header: {
-        label: 'Resources',
+        label: 'Assigned',
       },
       visible: false,
     },

--- a/src/components/Tickets/ToggleProjects/Projects.js
+++ b/src/components/Tickets/ToggleProjects/Projects.js
@@ -2,19 +2,19 @@ import React from 'react';
 
 const Projects = ({ projects, toggle, update }) => {
   return (
-    <ul 
+    <ul
       className="list-unstyled"
       style={{ marginBottom: '0' }}
     >
       {projects.map(project => (
-        <li 
+        <li
           key={project.id}
           style={{ display: 'block' }}
         >
           <label style={{ fontWeight: 'normal' }}>
             <input
               checked={project.selected}
-              style={{ marginRight: '10px' }} 
+              style={{ marginRight: '10px' }}
               type="checkbox"
               onChange={toggle.bind(this, project.id)}
             />

--- a/src/components/Tickets/ToggleProjects/Projects.js
+++ b/src/components/Tickets/ToggleProjects/Projects.js
@@ -18,10 +18,10 @@ const Projects = ({ projects, toggle, update }) => {
               type="checkbox"
               onChange={toggle.bind(this, project.id)}
             />
-            {project.company} &mdash; {project.name} ({project.id})
+            {project.company} &mdash; {project.name} <small>(ID: {project.id})</small>
 
-            <button 
-              className="btn-link"
+            <button
+              className="btn-link btn-sm"
               onClick={update.bind(this, project.id)}
               type="button"
             >

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,11 @@ body {
   padding: 15px;
 }
 
+.open > .toggl-description {
+  padding: 20px;
+  min-width: 400px;
+}
+
 .projects {
   display: block;
   position: relative;


### PR DESCRIPTION
This PR changes the Toggl start workflow. Currently, there are two ways to start a timer: click the large "Start" button, which begins a timer with the title of the ticket as the description; or click the small down arrow to reveal an empty description text field.

My proposal here is to remove the first option and simply pre-populate the text field with the default description. We _want_ users to provide a custom description more often than not. If one wants to keep the default, it's still possible.

I've also moved the input to a larger textarea to encourage users to write long-form descriptions of their work.

### New

<img width="383" alt="screen shot 2017-10-15 at 5 18 02 pm" src="https://user-images.githubusercontent.com/714017/31589268-dec06e44-b1cc-11e7-93e5-8bf81cb48d96.png">

### Old

<img width="383" alt="screen shot 2017-10-15 at 5 25 03 pm" src="https://user-images.githubusercontent.com/714017/31589335-d695f1f2-b1cd-11e7-90a0-ee9e2bc916c1.png">


Minor changes:

* 693fe6a changes the table header "Resources" to "Assigned." This is a more intuitive title in my opinion.
* b28a2c4 adds a placeholder to the manual ID entry field to show an example of a correct ID

    <img width="224" alt="screen shot 2017-10-15 at 5 18 47 pm" src="https://user-images.githubusercontent.com/714017/31589287-3e3fdce2-b1cd-11e7-97e8-ab1297722e3f.png">

*  54a6ba3 prefaces the ID in the project list with a label (I originally thought this was the number of tickets under the project). I'm actually not sure this is even worth keeping in the list – thoughts? When would this be needed?

    <img width="522" alt="screen shot 2017-10-15 at 5 23 05 pm" src="https://user-images.githubusercontent.com/714017/31589312-8c26243e-b1cd-11e7-8adb-8bb4837b72de.png">
