### PR TITLE
Add new showTotals option to columns and display them in footer table

### DIFF
--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -110,6 +110,12 @@ export default class TicketsTable extends React.Component {
     };
   }
 
+  footerSum(rows, property) {
+    return rows.reduce(function (a, b) {
+      return (typeof b[property] != 'undefined')? a + b[property] : a;
+    }, 0);
+  }
+
   render() {
     const { query } = this.props;
     const { columns, pagination, rows } = this.state;
@@ -118,6 +124,17 @@ export default class TicketsTable extends React.Component {
       search.multipleColumns({ columns, query })
     )(rows);
     const visibleColumns = columns.filter(column => column.visible);
+    const TableFooter = ({ columns, rows }) => {
+      return (
+        <tfoot>
+          <tr>
+            {columns.map((column, i) =>
+              <td key={`footer-${i}`}>{column.showTotals ? this.footerSum(rows, column.property) : null}</td>
+            )}
+          </tr>
+        </tfoot>
+      );
+    };
 
     return (
       <div>
@@ -159,6 +176,7 @@ export default class TicketsTable extends React.Component {
             />
           </Table.Header>
           <Table.Body rowKey="id" rows={paginated.rows} onRow={this.onBodyRow} />
+          <TableFooter columns={visibleColumns} rows={paginated.rows} />
         </Table.Provider>
         {paginated.amount > 1 && (
           <Pagination
@@ -246,6 +264,7 @@ TicketsTable.defaultProps = {
       props: {
         className: 'col--budget',
       },
+      showTotals: true,
     },
     {
       property: 'actualHours',
@@ -256,6 +275,7 @@ TicketsTable.defaultProps = {
       props: {
         className: 'col--budget',
       },
+      showTotals: true,
     },
     {
       property: 'status.name',
@@ -270,6 +290,7 @@ TicketsTable.defaultProps = {
         label: 'Billable',
       },
       visible: false,
+      showTotals: true,
     },
     {
       property: 'resources',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -126,7 +126,7 @@ export default class TicketsTable extends React.Component {
     const visibleColumns = columns.filter(column => column.visible);
     const TableFooter = ({ columns, rows }) => {
       return (
-        <tfoot>
+        <tfoot className="table-bordered__foot">
           <tr>
             {columns.map((column, i) =>
               <td key={`footer-${i}`}>{column.showTotals ? this.footerSum(rows, column.property) : null}</td>

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -113,8 +113,12 @@ export default class TicketsTable extends React.Component {
   footerSum(rows, property) {
     let sum = 0;
 
-    sum = rows.reduce(function (a, b) {
-      return (typeof b[property] != 'undefined')? a + b[property] : a;
+    sum = rows.map(row => row[property]).reduce((a, b) => {
+      if (!b) {
+        return a;
+      }
+
+      return a + b;
     }, 0);
 
     return Math.round(sum * 100) / 100;

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -111,14 +111,21 @@ export default class TicketsTable extends React.Component {
   }
 
   footerSum(rows, property) {
-    return rows.reduce(function (a, b) {
-      return (typeof b[property] != 'undefined')? a + b[property] : a;
-    }, 0);
+    let sum = 0;
+
+    if (typeof rows != 'undefined') {
+      sum = rows.reduce(function (a, b) {
+        return (typeof b[property] != 'undefined')? a + b[property] : a;
+      }, 0);
+    }
+
+    return Math.round(sum * 100) / 100;
   }
 
   render() {
     const { query } = this.props;
     const { columns, pagination, rows } = this.state;
+    const paginatedAll = compose(search.multipleColumns({ columns, query }))(rows);
     const paginated = compose(
       paginate(pagination),
       search.multipleColumns({ columns, query })
@@ -129,7 +136,7 @@ export default class TicketsTable extends React.Component {
         <tfoot className="table-bordered__foot">
           <tr>
             {columns.map((column, i) =>
-              <td key={`footer-${i}`}>{column.showTotals ? this.footerSum(rows, column.property) : null}</td>
+              <td key={`footer-${i}`}>{column.showTotals ? this.footerSum(paginatedAll, column.property) : null}</td>
             )}
           </tr>
         </tfoot>

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -290,7 +290,6 @@ TicketsTable.defaultProps = {
         label: 'Billable',
       },
       visible: false,
-      showTotals: true,
     },
     {
       property: 'resources',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -113,11 +113,9 @@ export default class TicketsTable extends React.Component {
   footerSum(rows, property) {
     let sum = 0;
 
-    if (typeof rows != 'undefined') {
-      sum = rows.reduce(function (a, b) {
-        return (typeof b[property] != 'undefined')? a + b[property] : a;
-      }, 0);
-    }
+    sum = rows.reduce(function (a, b) {
+      return (typeof b[property] != 'undefined')? a + b[property] : a;
+    }, 0);
 
     return Math.round(sum * 100) / 100;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -224,3 +224,9 @@ body {
 .ticket-copy .glyphicon-ok {
   color: #5cb85c;
 }
+
+/* Table Styling Adjustments */
+.table-bordered > tfoot.table-bordered__foot td {
+  font-weight: bold;
+  border-top-width: 2px;
+}


### PR DESCRIPTION
This full-fills my desire of column totals - https://github.com/nadavspi/UnwiseConnect/issues/44

### Feature Description:

Show totals of column values for all rows in result pool.

- To enable feature for a row add `showTotals: true` to column declaration.

<img width="206" alt="screen shot 2017-10-28 at 12 24 55 am" src="https://user-images.githubusercontent.com/3484527/32131219-65e96cba-bb76-11e7-9b7e-7611413cdb3c.png">

<img width="401" alt="screen shot 2017-10-28 at 12 26 53 am" src="https://user-images.githubusercontent.com/3484527/32131224-ac453680-bb76-11e7-8982-4bcbd44acfb7.png">
