### PR TITLE
Add class to ticket row if budget is close to exceed or exceeded budget

### DIFF
--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -87,6 +87,28 @@ export default class TicketsTable extends React.Component {
     this.setState({ columns });
   }
 
+  onBodyRow(row) {
+    const actualHours = row.actualHours;
+    const budgetHours = row.budgetHours;
+    let rowClass = null;
+
+    if (typeof budgetHours == 'undefined' && typeof actualHours == 'undefined') {
+      return;
+    }
+
+    if (actualHours > budgetHours) {
+      // over 100% of the budget is already used
+      rowClass = 'danger';
+    } else if (actualHours / budgetHours >= .9) {
+      // over 90% of the budget is already used
+      rowClass = 'warning';
+    }
+
+    return {
+      className: rowClass
+    };
+  }
+
   render() {
     const { query } = this.props;
     const { columns, pagination, rows } = this.state;
@@ -135,7 +157,7 @@ export default class TicketsTable extends React.Component {
               onChange={this.search}
             />
           </Table.Header>
-          <Table.Body rowKey="id" rows={paginated.rows} />
+          <Table.Body rowKey="id" rows={paginated.rows} onRow={this.onBodyRow} />
         </Table.Provider>
         {paginated.amount > 1 && (
           <Pagination

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -98,10 +98,10 @@ export default class TicketsTable extends React.Component {
 
     if (actualHours > budgetHours) {
       // over 100% of the budget is already used
-      rowClass = 'danger';
+      rowClass = 'ticket--overbudget';
     } else if (actualHours / budgetHours >= .9) {
       // over 90% of the budget is already used
-      rowClass = 'warning';
+      rowClass = 'ticket--nearbudget';
     }
 
     return {
@@ -242,6 +242,9 @@ TicketsTable.defaultProps = {
         label: 'Budget Hours',
       },
       visible: true,
+      props: {
+        className: 'col--budget',
+      },
     },
     {
       property: 'actualHours',
@@ -249,6 +252,9 @@ TicketsTable.defaultProps = {
         label: 'Actual Hours',
       },
       visible: true,
+      props: {
+        className: 'col--budget',
+      },
     },
     {
       property: 'status.name',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -92,7 +92,7 @@ export default class TicketsTable extends React.Component {
     const budgetHours = row.budgetHours;
     let rowClass = null;
 
-    if (typeof budgetHours == 'undefined' && typeof actualHours == 'undefined') {
+    if (typeof budgetHours == 'undefined' || typeof actualHours == 'undefined') {
       return;
     }
 

--- a/src/index.css
+++ b/src/index.css
@@ -194,3 +194,12 @@ body {
   transform: translateZ(0);
   animation: spin 0.6s infinite ease-in;
 }
+
+
+.ticket--overbudget .col--budget {
+  background-color: #f2dede;
+}
+
+.ticket--nearbudget .col--budget {
+  background-color: #fcf8e3;
+}


### PR DESCRIPTION
Satisfies my desire for colored table rows - https://github.com/nadavspi/UnwiseConnect/issues/17

Color rows that are near or over budget for easy visibility. Color is OOB bootstrap danger & warning. Warning (yellow) gets applied when ticket actual is 90% or more of budget. If Budget is 0 no color is applied as that's considered `undefined`.

<img width="375" alt="screen shot 2017-10-28 at 12 55 27 am" src="https://user-images.githubusercontent.com/3484527/32131425-a71b5d4c-bb7b-11e7-9f85-d97a5c196cab.png">
