### PR TITLE
Sort Project Tickets by wbsCode

### DIFF
--- a/src/actions/tickets.js
+++ b/src/actions/tickets.js
@@ -14,6 +14,22 @@ export const subscribe = ({ projectId }) => {
       const nested = snapshot.val();
       const flattened = Object.keys(nested).map(project => nested[project]).reduce((prev, next) => prev.concat(next), []);
 
+      // Sort project ticket by wbsCode
+      // ie ['1.1', '1.1.14', '4.2.1.4.6', '4.2.3']
+      flattened.sort((a, b) => {
+        const aParts = a.wbsCode.split('.');
+        const bParts = b.wbsCode.split('.');
+        for (let i = 0; i < aParts.length; ++i) {
+          if (bParts.length == i || parseInt(aParts[i], 10) > parseInt(bParts[i], 10)) {
+            return 1;
+          } else if (parseInt(aParts[i], 10) === parseInt(bParts[i], 10)) {
+            continue;
+          } else {
+            return -1;
+          }
+        }
+      });
+
       dispatch({
         type: ActionTypes.TICKETS_UPDATE,
         payload: {


### PR DESCRIPTION
Use a sort method similar to what is used by version compare libraries.
The sort occurs only during the initial ticket load.

Screenshot of tickets sorted by wbsCode with wbsCode and dateEntered
columns added for illustration only.
![screen shot 2017-11-30 at 6 13 36 pm](https://user-images.githubusercontent.com/12674247/33460027-52f712e4-d5fa-11e7-92b6-65dcc0380f97.png)

Fixes #33