### PR TITLE
Leave timer description empty by default

### DIFF
--- a/src/components/Tickets/StartTimer.js
+++ b/src/components/Tickets/StartTimer.js
@@ -33,7 +33,6 @@ class StartTimer extends Component {
 
     this.setState({
       expanded: willExpand,
-      description: this.props.ticket.summary,
     }, () => {
       if (willExpand) {
         this.input.focus();


### PR DESCRIPTION
Rather than defaulting to the ticket name. This is better for two
reasons:

1. It encourages people to enter a real description instead of lazily using the
   name of the ticket.
2. If you already have a timer running in Toggl, clicking Start Timer when
   description is empty will append the ticket number to your existing timer.