### PR TITLE
Add link to CW view in Select Project dropdown

### DIFF
--- a/src/components/Tickets/ToggleProjects/Projects.js
+++ b/src/components/Tickets/ToggleProjects/Projects.js
@@ -18,7 +18,7 @@ const Projects = ({ projects, toggle, update }) => {
               type="checkbox"
               onChange={toggle.bind(this, project.id)}
             />
-            {project.company} &mdash; {project.name} <small>(ID: {project.id})</small>
+            {project.company} &mdash; {project.name} <small><a href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + "/services/system_io/router/openrecord.rails?recordType=ProjectHeaderFV&recid=" + project.id} target="_blank" rel="noopener">(ID: {project.id})</a></small>
 
             <button
               className="btn-link btn-sm"


### PR DESCRIPTION
We don't have an easy method to get to the actual CW project right now. This should ameliorate that some.