### PR TITLE
Fix pagination jump on main index

### DIFF
--- a/src/components/Tickets/index.js
+++ b/src/components/Tickets/index.js
@@ -104,7 +104,7 @@ class Tickets extends Component {
             </div>
           </div>
           <div className="row panel-body">
-            <div className="panel-body col-md-6 projects__wrapper">
+            <div className="panel-body projects__wrapper">
               <h2>Active Projects</h2>
               <Projects
                 projects={this.projects()}


### PR DESCRIPTION
`.col-md-6` floats elements, which in turn means the (uncleared) sibling ticket table has this element within its box model. This makes pagination's anchor target much higher than it should be.