### PR TITLE
Search by full phase path and allow negative filters

### DIFF
--- a/src/components/Dispatch/index.js
+++ b/src/components/Dispatch/index.js
@@ -188,11 +188,24 @@ class Dispatch extends Component {
         visible: true,
       },
       {
-        property: 'phase.name',
+        property: 'phase.path',
         header: {
           label: 'Phase',
         },
-        visible: true,
+        visible: false,
+        cell: {
+          resolve: value => `(${value})`,
+          formatters: [
+            (value, { rowData }) => {
+              const { name, path } = rowData.phase;
+              return (
+                <span title={path}>
+                  {name}
+                </span>
+              );
+            }
+          ]
+        },
       },
       {
         property: 'summary',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -280,11 +280,24 @@ TicketsTable.defaultProps = {
       filterType: 'none',
     },
     {
-      property: 'phase.name',
+      property: 'phase.path',
       header: {
         label: 'Phase',
       },
       visible: false,
+      cell: {
+        resolve: value => `(${value})`,
+        formatters: [
+          (value, { rowData }) => {
+            const { name, path } = rowData.phase;
+            return (
+              <span title={path}>
+                {name}
+              </span>
+            );
+          }
+        ]
+      },
     },
     {
       property: 'summary',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -9,6 +9,7 @@ import TicketLink from './TicketLink';
 import VisibilityToggles from 'react-visibility-toggles';
 import cloneDeep from 'lodash.clonedeep';
 import { compose } from 'redux';
+import { multiInfix } from '../../helpers/utils';
 
 function paginate({ page, perPage }) {
   return (rows = []) => {
@@ -25,27 +26,6 @@ function paginate({ page, perPage }) {
     };
   };
 }
-
-const multiInfix = term => ({
-  evaluate(value = '') {
-    if (!value) {
-      return false;
-    }
-
-    if (Array.isArray(value)) {
-      return value.some(v => this.doMatch(term, v));
-    }
-    if (Array.isArray(term)) {
-      return term.some(v => this.doMatch(v, value));
-    }
-
-    return this.doMatch(term, value);
-  },
-
-  doMatch(query, value) {
-    return value.indexOf(query) !== -1;
-  }
-});
 
 export default class TicketsTable extends React.Component {
   constructor(props) {

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -11,3 +11,26 @@ export function checkStatus(response) {
 export function parseJSON(response) {
   return response.json();
 }
+
+export function multiInfix(term) {
+  return {
+    evaluate(value = '') {
+      if (!value) {
+        return false;
+      }
+
+      if (Array.isArray(value)) {
+        return value.some(v => this.doMatch(term, v));
+      }
+      if (Array.isArray(term)) {
+        return term.some(v => this.doMatch(v, value));
+      }
+
+      return this.doMatch(term, value);
+    },
+
+    doMatch(query, value) {
+      return value.indexOf(query) !== -1;
+    }
+  };
+}

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -20,11 +20,12 @@ function termToWords(term) {
   let words = [];
 
   let last = 0;
+  let nextSemantic = '+';
   const addWord = (end, quoted) => {
     // Skip blank words, even "".
     if (end !== last) {
       let text = term.substr(last, end - last);
-      let semantic = '+';
+      let semantic = nextSemantic;
 
       // If it's not quoted, check if it has a semantic prefix.
       if (!quoted && text.length > 1) {
@@ -36,6 +37,7 @@ function termToWords(term) {
       }
 
       words.push({ text, semantic });
+      nextSemantic = '+';
     }
 
     // This always has a separator following it, skip that.
@@ -57,7 +59,19 @@ function termToWords(term) {
         // We already skipped the first quote when we set inQuotes.
         addWord(next.index, true);
         inQuotes = false;
+        // In case it was -"", reset nextSemantic.
+        nextSemantic = '+';
       } else {
+        // Might be a semantic before the quoted string.
+        if (next.index === last + 1) {
+          const maybeSemantic = term.substr(last, 1);
+          if (maybeSemantic === '-' || maybeSemantic === '+') {
+            nextSemantic = maybeSemantic;
+            // Skip considering this in addWord().
+            last = next.index;
+          }
+        }
+
         // Everything up to the start quote is a word.
         addWord(next.index, false);
         inQuotes = true;

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,3 +1,5 @@
+/* eslint no-cond-assign: ["error", "except-parens"] */
+
 export function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response
@@ -12,7 +14,66 @@ export function parseJSON(response) {
   return response.json();
 }
 
-export function multiInfix(term) {
+// This function converts 'Hello "foo bar" -baz' into:
+// [ {text: 'Hello', semantic: '+'}, {text: 'foo bar', semantic: '+'}, {text: 'baz', semantic: '-'}]
+function termToWords(term) {
+  let words = [];
+
+  let last = 0;
+  const addWord = (end, quoted) => {
+    // Skip blank words, even "".
+    if (end !== last) {
+      let text = term.substr(last, end - last);
+      let semantic = '+';
+
+      // If it's not quoted, check if it has a semantic prefix.
+      if (!quoted) {
+        const prefix = text.substr(0, 1);
+        if (prefix === '-' || prefix === '+') {
+          semantic = prefix;
+          text = text.substr(1);
+        }
+      }
+
+      words.push({ text, semantic });
+    }
+
+    // This always has a separator following it, skip that.
+    last = end + 1;
+  };
+
+  let inQuotes = false;
+  let reg = /"| /g;
+  let next = null;
+  // This will iterate through each separator.
+  while ((next = reg.exec(term)) !== null) {
+    const c = next[0];
+
+    // Ignore any space inside quotes, and just keep going.
+    if (c === ' ' && !inQuotes) {
+      addWord(next.index, false);
+    } else if (c === '"') {
+      if (inQuotes) {
+        // We already skipped the first quote when we set inQuotes.
+        addWord(next.index, true);
+        inQuotes = false;
+      } else {
+        // Everything up to the start quote is a word.
+        addWord(next.index, false);
+        inQuotes = true;
+      }
+    }
+  }
+
+  // Okay, and finally do the last word.  End quotes immediately, etc.
+  if (last < term.length) {
+    addWord(term.length, inQuotes);
+  }
+
+  return words;
+}
+
+function arrayInfix(term) {
   return {
     evaluate(value = '') {
       if (!value) {
@@ -22,11 +83,66 @@ export function multiInfix(term) {
       if (Array.isArray(value)) {
         return value.some(v => this.doMatch(term, v));
       }
-      if (Array.isArray(term)) {
-        return term.some(v => this.doMatch(v, value));
+
+      return term.some(v => this.doMatch(v, value));
+    },
+
+    doMatch(query, value) {
+      return value.indexOf(query) !== -1;
+    }
+  };
+}
+
+function plainInfix(term) {
+  return {
+    evaluate(value = '') {
+      if (!value) {
+        return false;
+      }
+
+      if (Array.isArray(value)) {
+        return value.some(v => this.doMatch(term, v));
       }
 
       return this.doMatch(term, value);
+    },
+
+    doMatch(query, value) {
+      return value.indexOf(query) !== -1;
+    }
+  };
+}
+
+export function multiInfix(term) {
+  if (Array.isArray(term)) {
+    return arrayInfix(term);
+  }
+
+  // If term has any parts starting with -, exclude those.
+  const words = termToWords(term);
+  const positiveWords = words.filter(word => word.semantic === '+').map(word => word.text);
+  const negativeWords = words.filter(word => word.semantic === '-').map(word => word.text);
+
+  // For backwards compatible filter behavior, skip without negative words.
+  // The difference is that this does word matching ("a" and "b"), not phrase matching ("a b".)
+  if (negativeWords.length === 0) {
+    return plainInfix(term);
+  }
+
+  return {
+    evaluate(value = '') {
+      if (!value) {
+        return false;
+      }
+
+      if (Array.isArray(value)) {
+        return value.some(v => this.doMatch(term, v));
+      }
+
+      if (negativeWords.some(v => this.doMatch(v, value))) {
+        return false;
+      }
+      return positiveWords.every(v => this.doMatch(v, value));
     },
 
     doMatch(query, value) {

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -27,7 +27,7 @@ function termToWords(term) {
       let semantic = '+';
 
       // If it's not quoted, check if it has a semantic prefix.
-      if (!quoted) {
+      if (!quoted && text.length > 1) {
         const prefix = text.substr(0, 1);
         if (prefix === '-' || prefix === '+') {
           semantic = prefix;


### PR DESCRIPTION
This does two things, which solve problems for me around phase filtering:

1. Filter the full phase path in results, i.e. Dev/Foo/Bar/Baz.  Still displays only Baz, but shows the full path via `title=""`.
2. Allow negative filtering, i.e. `"Sprint 1" -Demo`.  This uses word matching.

To avoid surprises, continues to use phrase matching for searches which don't include hyphen prefixed words (e.g. `Sprint 1` will continue to match the phrase "Sprint 1" instead of "Sprint" and "1".)