### PR TITLE
Group all active projects together at the top

### DIFF
--- a/src/components/Tickets/ToggleProjects/index.js
+++ b/src/components/Tickets/ToggleProjects/index.js
@@ -57,7 +57,15 @@ class ToggleProjects extends Component {
           style={{ width: '700px', height: 'auto', maxHeight: '60vh', overflowY: 'auto' }}
         >
           <Projects
-            projects={projects}
+            projects={projects.filter(project => project.selected)}
+            toggle={this.toggle}
+            update={this.updateTickets}
+          />
+          {(projects.filter(project => project.selected).length ?
+            <hr />
+          : '')}
+          <Projects
+            projects={projects.filter(project => !project.selected)}
             toggle={this.toggle}
             update={this.updateTickets}
           />


### PR DESCRIPTION
They're probably the most interesting, after all.

Fixes #30, although it doesn't actually duplicate the active projects within the list (I think it's better not to.)