### PR TITLE
Only append 'hrs' to table data

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -213,8 +213,8 @@ body {
 .col--budget {
   text-align: right;
 }
-
-.col--budget:not(:empty)::after {
+  
+td.col--budget:not(:empty)::after {
   content: ' hrs';
 }
 


### PR DESCRIPTION
Nuance to #83 - we don't want the table headers to have 'hrs' as well

E.g

![screen shot 2018-05-29 at 9 58 08 am](https://user-images.githubusercontent.com/714017/40663506-d0b0be88-6326-11e8-9c29-52fe33ce14e1.png)
