### PR TITLE
Show ticket copy button when hovering ID

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -235,8 +235,8 @@ td.col--budget:not(:empty)::after {
   visibility: hidden;
 }
 
-.ticket-copy:hover .glyphicon-copy,
-.ticket-copy:focus .glyphicon-copy {
+.ticket-link:focus .glyphicon-copy, 
+.ticket-copy:hover .glyphicon-copy {
   visibility: visible
 }
 


### PR DESCRIPTION
A tiny tweak to how the copy button shows up. You currently have to hover over the (hidden) icon for it to show. This PR makes the trigger to show it the entire ticket cell.

![screen recording 2018-05-29 at 10 49 pm](https://user-images.githubusercontent.com/714017/40696182-bfd58f1e-6392-11e8-9a9a-ba3819fe1c09.gif)
