### PR TITLE
Support Sprint custom field for tickets

### DIFF
--- a/src/components/Dispatch/Fields/index.js
+++ b/src/components/Dispatch/Fields/index.js
@@ -23,6 +23,7 @@ const Field = ({ field, onChange, tickets }) => {
             {field.id}
           </label>
           <input
+            className="form-control"
             id={field.id}
             onChange={onChange}
             required={field.required}
@@ -34,17 +35,16 @@ const Field = ({ field, onChange, tickets }) => {
 
     case 'boolean':
       return (
-        <span>
-          <input
-            checked={field.value}
-            id={field.id}
-            onChange={onChange}
-            type="checkbox"
-          />
-          {' '}
+        <span className="checkbox">
           <label
             htmlFor={field.id}
           >
+            <input
+              checked={field.value}
+              id={field.id}
+              onChange={onChange}
+              type="checkbox"
+            />
             {field.id}
           </label>
         </span>
@@ -61,6 +61,7 @@ const Field = ({ field, onChange, tickets }) => {
           </label>
 
           <select
+            className="form-control"
             id={field.id}
             onChange={onChange}
             required={field.required}
@@ -118,7 +119,10 @@ const Fields = props => {
   return (
     <div className="dispatch-fields">
       {props.fields.map(field => (
-        <div key={field.id}>
+        <div 
+          className="form-group"
+          key={field.id}
+        >
           <Field
             field={field}
             onChange={props.onChange.bind(null, field.id, field.type)}

--- a/src/components/Dispatch/index.js
+++ b/src/components/Dispatch/index.js
@@ -1,17 +1,18 @@
 import './dispatch.css';
-import * as resolve from 'table-resolver';
 import * as UserActions from '../../actions/user';
+import * as resolve from 'table-resolver';
+import * as searchtabular from 'searchtabular';
 import Fields from './Fields';
 import JSONPretty from 'react-json-pretty';
 import Queue from './Queue';
 import React, { Component } from 'react';
 import Table from '../Tickets/Table';
-import * as searchtabular from 'searchtabular';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { customField } from '../../config/columns';
 import { format as formatDate } from 'date-fns';
-import { search, dispatch as dispatchTickets } from '../../actions/tickets';
 import { multiInfix } from '../../helpers/utils';
+import { search, dispatch as dispatchTickets } from '../../actions/tickets';
 
 const fields = [
   {
@@ -228,6 +229,15 @@ class Dispatch extends Component {
               );
             }
           ]
+        },
+      },
+      {
+        property: 'customFields',
+        header: {
+          label: 'Sprint',
+        },
+        cell: {
+          ...customField('Sprint'),
         },
       },
       {

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -333,6 +333,35 @@ TicketsTable.defaultProps = {
       },
     },
     {
+      property: 'customFields',
+      header: {
+        label: 'Sprint',
+      },
+      cell: {
+        resolve: field => {
+          if (!field) {
+            return 'N/A';
+          }
+
+          const sprint = field.find(val => val.caption === 'Sprint');
+          if (sprint && sprint.value) {
+            return sprint.value;
+          }
+
+          return 'N/A';
+        },
+        formatters: [
+          (field, { rowData }) => {
+            if (field === 'N/A') {
+              return <div />;
+            }
+
+            return <div>{field}</div>;
+          }
+        ],
+      },
+    },
+    {
       property: 'budgetHours',
       header: {
         label: 'Budget Hours',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -343,15 +343,6 @@ TicketsTable.defaultProps = {
       },
     },
     {
-      property: 'customFields',
-      header: {
-        label: 'Test',
-      },
-      cell: {
-        ...customField('Test'),
-      },
-    },
-    {
       property: 'budgetHours',
       header: {
         label: 'Budget Hours',

--- a/src/components/Tickets/Table.js
+++ b/src/components/Tickets/Table.js
@@ -1,14 +1,15 @@
 import * as Table from 'reactabular-table';
 import * as resolve from 'table-resolver';
 import * as search from 'searchtabular';
-import Pagination from './Pagination';
 import DetailsModal from './DetailsModal';
+import Pagination from './Pagination';
 import React from 'react';
 import SearchColumns from './SearchColumns';
 import StartTimer from './StartTimer';
 import TicketLink from './TicketLink';
 import VisibilityToggles from 'react-visibility-toggles';
 import { compose } from 'redux';
+import { customField } from '../../config/columns';
 import { multiInfix } from '../../helpers/utils';
 
 function paginate({ page, perPage }) {
@@ -338,27 +339,16 @@ TicketsTable.defaultProps = {
         label: 'Sprint',
       },
       cell: {
-        resolve: field => {
-          if (!field) {
-            return 'N/A';
-          }
-
-          const sprint = field.find(val => val.caption === 'Sprint');
-          if (sprint && sprint.value) {
-            return sprint.value;
-          }
-
-          return 'N/A';
-        },
-        formatters: [
-          (field, { rowData }) => {
-            if (field === 'N/A') {
-              return <div />;
-            }
-
-            return <div>{field}</div>;
-          }
-        ],
+        ...customField('Sprint'),
+      },
+    },
+    {
+      property: 'customFields',
+      header: {
+        label: 'Test',
+      },
+      cell: {
+        ...customField('Test'),
       },
     },
     {

--- a/src/config/columns.js
+++ b/src/config/columns.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export const customField = caption => {
+  return {
+    resolve: field => {
+      if (!field) {
+        return 'N/A';
+      }
+
+      const sprint = field.find(val => val.caption === caption);
+      if (sprint && sprint.value) {
+        return sprint.value;
+      }
+
+      return 'N/A';
+    },
+    formatters: [
+      (field, { rowData }) => {
+        if (field === 'N/A') {
+          return <div />;
+        }
+
+        return <div>{field}</div>;
+      }
+    ],
+  }
+};


### PR DESCRIPTION
Turns out that ConnectWise supports custom fields: https://docs.connectwise.com/ConnectWise_Documentation/090/020/070/038.

This PR add supports for a "Sprint" column. A future PR will add a sprint input to the dispatch form, which the API will use to set the value of the custom field when dispatching.