### PR TITLE
Speed up search rendering and prevent table from resizing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -174,6 +174,10 @@ body {
   margin-left: auto;
 }
 
+#table-search-tickets table {
+  table-layout: fixed;
+}
+
 .column-filter-input {
   width: 100%;
 }


### PR DESCRIPTION
[`table-layout: fixed`](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) allows us to prevent the ticket list table from changing column widths on searches, which can be distracting and costly via a vis performance. The actual speed up from the reduced paint time is not large but it subjectively *feels* quite a bit faster. 

### Before

![Screen Recording 2019-10-05 at 06 43 PM](https://user-images.githubusercontent.com/714017/66261688-1f742600-e7a0-11e9-90f7-27849c3503d2.gif)

### After

![Screen Recording 2019-10-05 at 06 45 PM](https://user-images.githubusercontent.com/714017/66261700-4b8fa700-e7a0-11e9-9da2-b94c97643981.gif)

## Next Steps

Cells wrap earlier on a fixed layout, which makes long ticket names harder to read. 

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/714017/66263280-e3e85480-e7bd-11e9-90df-6055a57e97be.png) | ![image](https://user-images.githubusercontent.com/714017/66263267-a388d680-e7bd-11e9-9f57-740c2e642694.png) |

This is because each column is now the same size. We'll next need to assign widths to the rows that have shorter content in them (Toggl, ID, hours, etc), which will permit Name to have a width like this:
![image](https://user-images.githubusercontent.com/714017/66263298-725cd600-e7be-11e9-97ca-8b02cfa7d1fb.png)
