### PR TITLE
Switch date dispatch inputs to browser datepickers

### DIFF
--- a/src/components/Dispatch/index.js
+++ b/src/components/Dispatch/index.js
@@ -65,14 +65,14 @@ const fields = [
     id: 'startDate',
     label: 'Start date',
     value: formatDate(new Date(), 'yyyy-MM-dd'),
-    type: 'text',
+    type: 'date',
     required: true,
   },
   {
     id: 'endDate',
     label: 'End date',
     value: '',
-    type: 'text',
+    type: 'date',
     required: false,
   },
   {


### PR DESCRIPTION
Fixes #119

We'll at some point need to use an actual React datepicker for browser compat sake (Safari does not support this), but this switch is at the very least a nice upgrade for Firefox and Chrome users. Unsupported inputs gracefully degrade to a text input, so not a major concern.

Note that the format in this screenshot doesn't match our expected input format (yyyy-mm-dd). That's OK, the seen format != the input value. [From MDN:](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Value)

> **The displayed date format will differ from the actual `value`** — the displayed date is formatted *based on the locale of the user's browser,* but the parsed `value` is always formatted `yyyy-mm-dd`.

![image](https://user-images.githubusercontent.com/714017/66261857-bd68f000-e7a2-11e9-9a15-364139a318f0.png)
