### PR TITLE
Cap project list height to show internal scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+$ease-out-circ: cubic-bezier(0.075, 0.820, 0.165, 1.000);
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
@@ -122,7 +124,9 @@ body {
   }
 
   .projects:hover {
-    max-height: none;
+    max-height: 500px;
+    transition: max-height 0.2s $ease-out-circ;
+    overflow: auto;
     box-shadow: none;
     border: solid 1px #bbbbbb;
     margin: 0;


### PR DESCRIPTION
This way you don't have to scroll the entire page  when navigating the list

![Screen Recording 2019-10-05 at 10 54 PM](https://user-images.githubusercontent.com/714017/66263567-282a2380-e7c3-11e9-9408-2ccab52cb268.gif)
