### PR TITLE
Add America/Chicago (Central time) as timezone option

### DIFF
--- a/src/components/Dispatch/index.js
+++ b/src/components/Dispatch/index.js
@@ -82,6 +82,7 @@ const fields = [
       'America/New_York',
       'America/Phoenix',
       'America/Los_Angeles',
+      'America/Chicago',
       'Europe/Kiev',
       'Asia/Kolkata',
     ],


### PR DESCRIPTION
Adds value 'America/Chicago' as an available timezone so that it will populate  in the timezone dropdown for dispatching