### PR TITLE
Add Europe/Moscow timezone in dropdown

### DIFF
--- a/src/components/Dispatch/index.js
+++ b/src/components/Dispatch/index.js
@@ -83,6 +83,7 @@ const fields = [
       'America/Phoenix',
       'America/Los_Angeles',
       'Europe/Kiev',
+      'Europe/Moscow',
       'Asia/Kolkata',
     ],
     value: 'America/New_York',


### PR DESCRIPTION
Europe/Moscow is frequently used by our contract developers