### PR TITLE
Refactor TimeEntries and ScheduleEntries components to use React hooks

### DIFF
--- a/src/components/Tickets/DetailsModal/ScheduleEntries.js
+++ b/src/components/Tickets/DetailsModal/ScheduleEntries.js
@@ -6,10 +6,6 @@ const ScheduleEntries = ({ ticketNumber }) =>  {
   const [entries, setEntries] = React.useState([]);
   const [isLoading, setIsLoading] = React.useState(false);
 
-  React.useEffect(() =>  {
-      displayEntries();
-  }, []);
-
   const displayEntries = () => {
     setIsLoading(true);
     fetchTicketScheduleEntryIds(ticketNumber).then(results => {
@@ -20,7 +16,11 @@ const ScheduleEntries = ({ ticketNumber }) =>  {
       setEntries(entries);
       setIsLoading(false);
     });
-  }
+  };
+
+  React.useEffect(() =>  {
+      displayEntries();
+  }, []);
 
   const entryCard = entry => {
     let startDate = entry.dateStart;
@@ -45,7 +45,7 @@ const ScheduleEntries = ({ ticketNumber }) =>  {
         <td>{(entry.doneFlag) ? <div className="glyphicon glyphicon-ok" aria-hidden="true" /> : ''}</td>
       </React.Fragment>
     );
-  }
+  };
 
   return (
     <div>
@@ -72,6 +72,6 @@ const ScheduleEntries = ({ ticketNumber }) =>  {
         </table>
     </div>
   );
-}
+};
 
 export default ScheduleEntries;

--- a/src/components/Tickets/DetailsModal/ScheduleEntries.js
+++ b/src/components/Tickets/DetailsModal/ScheduleEntries.js
@@ -1,37 +1,28 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { fetchScheduleEntryById, fetchTicketScheduleEntryIds } from '../../../helpers/cw';
 
-class ScheduleEntries extends Component {
-  constructor() {
-    super();
+const ScheduleEntries = ({ ticketNumber }) =>  {
 
-    this.state = { 
-      entries: [],
-      isLoading: false,
-    };
+  const [entries, setEntries] = React.useState([]);
+  const [isLoading, setIsLoading] = React.useState(false);
 
-    this.displayEntries = this.displayEntries.bind(this);
-  }
+  React.useEffect(() =>  {
+      displayEntries();
+  }, []);
 
-  componentWillMount() {
-    this.displayEntries();
-  }
-
-  displayEntries() {
-    fetchTicketScheduleEntryIds(this.props.ticketNumber).then(results => {
+  const displayEntries = () => {
+    setIsLoading(true);
+    fetchTicketScheduleEntryIds(ticketNumber).then(results => {
       return Promise.all(results.map(result => {
         return fetchScheduleEntryById(result);
       }));
     }).then(entries => {
-      this.setState({
-        ...this.state,
-        entries: entries,
-        isLoading: false,
-      });
+      setEntries(entries);
+      setIsLoading(false);
     });
   }
 
-  entryCard(entry) {
+  const entryCard = entry => {
     let startDate = entry.dateStart;
     let endDate = entry.dateEnd;
 
@@ -51,40 +42,36 @@ class ScheduleEntries extends Component {
         <td>{startDate}</td>
         <td>{endDate}</td>
         <td>{entry.hours}</td>
-        <td>{(entry.doneFlag) ? <div class="glyphicon glyphicon-ok" aria-hidden="true"></div> : ''}</td>
+        <td>{(entry.doneFlag) ? <div className="glyphicon glyphicon-ok" aria-hidden="true" /> : ''}</td>
       </React.Fragment>
     );
   }
 
-  render() {
-    return (
-      <div>
-          <h4>Schedule Entries</h4>
-          {(this.state.isLoading) && (
-            <p style={{textAlign: 'center'}}>Loading . . . </p>
-          )}
-          <table className="table table-striped table-bordered">
-            <thead>
-              <tr>
-                <th>Member Name</th>
-                <th>Start Date</th>
-                <th>End Date</th>
-                <th>Hours</th>
-                <th>Done</th>
-              </tr>
-            </thead>
+  return (
+    <div>
+        <h4>Schedule Entries</h4>
+        {isLoading && (<p style={{textAlign: 'center'}}>Loading &hellip;</p>)}
+        <table className="table table-striped table-bordered">
+          <thead>
+            <tr>
+              <th>Member Name</th>
+              <th>Start Date</th>
+              <th>End Date</th>
+              <th>Hours</th>
+              <th>Done</th>
+            </tr>
+          </thead>
 
-            <tbody>
-              {this.state.entries.map(entry =>
-                <tr key={entry.id}>
-                  {this.entryCard(entry)}
-                </tr>
-              )}
-            </tbody>
-          </table>
-      </div>
-    );
-  }
+          <tbody>
+            {entries.map(entry =>
+              <tr key={entry.id}>
+                {entryCard(entry)}
+              </tr>
+            )}
+          </tbody>
+        </table>
+    </div>
+  );
 }
 
 export default ScheduleEntries;

--- a/src/components/Tickets/DetailsModal/TimeEntries.js
+++ b/src/components/Tickets/DetailsModal/TimeEntries.js
@@ -1,37 +1,29 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { fetchTimeEntryById, fetchTicketTimeEntryIds } from '../../../helpers/cw';
 
-class TimeEntries extends Component {
-  constructor() {
-    super();
+const TimeEntries = ({ticketNumber}) => {
 
-    this.state = { 
-      entries: [],
-      isLoading: false,
-    };
+  const [entries, setEntries] = React.useState([]);
+  const [isLoading, setIsLoading] = React.useState(false);
 
-    this.displayEntries = this.displayEntries.bind(this);
-  }
+  const displayEntries = () => {
+    setIsLoading(true);
 
-  componentWillMount() {
-    this.displayEntries();
-  }
-
-  displayEntries() {
-    fetchTicketTimeEntryIds(this.props.ticketNumber).then(results => {
+    fetchTicketTimeEntryIds(ticketNumber).then(results => {
       return Promise.all(results.map(result => {
         return fetchTimeEntryById(result);
       }));
     }).then(entries => {
-      this.setState({
-        ...this.state,
-        entries: entries,
-        isLoading: false,
-      });
+      setIsLoading(false);
+      setEntries(entries);
     });
   }
 
-  entryCard(entry) {
+  React.useEffect(() => {
+    displayEntries();
+  }, [])
+
+  const entryCard = (entry) => {
     const date = (new Date(entry.timeStart)).toLocaleDateString() + ' ' + (new Date(entry.timeStart)).toLocaleTimeString();
     return(
       <React.Fragment>
@@ -43,33 +35,29 @@ class TimeEntries extends Component {
     );
   }
 
-  render() {
-    return (
-      <div>
-          <h4>Time Entries</h4>
-          {(this.state.isLoading) && (
-            <p style={{textAlign: 'center'}}>Loading . . . </p>
+  return (
+    <div>
+        <h4>Time Entries</h4>
+        {isLoading && (<p style={{textAlign: 'center'}}>Loading &hellip;</p>)}
+        <table className="table table-striped table-bordered">
+          <thead>
+            <tr>
+              <th>Member Name</th>
+              <th>Notes</th>
+              <th>Actual Hours</th>
+              <th>Entry Date</th>
+            </tr>
+          </thead>
+          <tbody>
+          {entries.map(entry =>
+            <tr key={entry.id}>
+              {entryCard(entry)}
+            </tr>
           )}
-          <table className="table table-striped table-bordered">
-            <thead>
-              <tr>
-                <th>Member Name</th>
-                <th>Notes</th>
-                <th>Actual Hours</th>
-                <th>Entry Date</th>
-              </tr>
-            </thead>
-            <tbody>
-            {this.state.entries.map(entry =>
-              <tr key={entry.id}>
-                {this.entryCard(entry)}
-              </tr>
-            )}
-            </tbody>
-          </table>
-      </div>
-    );
-  }
+          </tbody>
+        </table>
+    </div>
+  );
 }
 
 export default TimeEntries;

--- a/src/components/Tickets/DetailsModal/TimeEntries.js
+++ b/src/components/Tickets/DetailsModal/TimeEntries.js
@@ -17,11 +17,11 @@ const TimeEntries = ({ticketNumber}) => {
       setIsLoading(false);
       setEntries(entries);
     });
-  }
+  };
 
   React.useEffect(() => {
     displayEntries();
-  }, [])
+  }, []);
 
   const entryCard = (entry) => {
     const date = (new Date(entry.timeStart)).toLocaleDateString() + ' ' + (new Date(entry.timeStart)).toLocaleTimeString();
@@ -33,7 +33,7 @@ const TimeEntries = ({ticketNumber}) => {
         <td>{date}</td>
       </React.Fragment>
     );
-  }
+  };
 
   return (
     <div>
@@ -58,6 +58,6 @@ const TimeEntries = ({ticketNumber}) => {
         </table>
     </div>
   );
-}
+};
 
 export default TimeEntries;


### PR DESCRIPTION
Upgrade TimeEntries and SchedulEntries to use React hooks.
Prevents use of deprecated componentWillMount
Fixes issue were loading indicator was not displaying because the state was not set to isLoading: true
Uses &hellip; instead of `. . .` for loading indicator

See issue #130 