### PR TITLE
Remove verb on project dropdown

### DIFF
--- a/src/components/Tickets/ToggleProjects/index.js
+++ b/src/components/Tickets/ToggleProjects/index.js
@@ -66,7 +66,7 @@ class ToggleProjects extends Component {
           type="button"
           onClick={e => this.setState({ expanded: !expanded})}
         >
-          Select Projects {' '}
+          My Projects {' '}
           <span className="caret"></span>
         </button>
         <div


### PR DESCRIPTION
This dropdown serves as the interface to both select AND update projects. Let's remove the verb "Select" to clarify