### PR TITLE
Close Projects Modal When You Click Out of It

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-beautiful-dnd": "^11.0.4",
+    "react-click-outside": "^3.0.1",
     "react-csv": "^1.0.14",
     "react-dom": "^16.8.6",
     "react-json-pretty": "^1.7.4",

--- a/src/components/Tickets/ToggleProjects/index.js
+++ b/src/components/Tickets/ToggleProjects/index.js
@@ -3,6 +3,7 @@ import * as TicketsActions from '../../../actions/tickets';
 import Projects from './Projects';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import enhanceWithClickOutside from 'react-click-outside';
 import sortBy from 'sort-by';
 import { connect } from 'react-redux';
 
@@ -34,6 +35,12 @@ class ToggleProjects extends Component {
 
   handleSearchChange(event) {
     this.setState({searchTerm: event.target.value});
+  }
+
+  handleClickOutside() {
+    this.setState({
+      expanded: false,
+    })
   }
 
   render() {
@@ -105,4 +112,4 @@ const mapStateToProps = state => ({
   projects: state.projects.sort(sortBy('company', 'name')),
   userProjects: state.user.projects,
 });
-export default connect(mapStateToProps)(ToggleProjects);
+export default connect(mapStateToProps)(enhanceWithClickOutside(ToggleProjects));

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,9 @@ const store = createStore(
 const load = storage.createLoader(engine);
 load(store);
 
- ReactDOM.render(
-   <Provider store={store}>
-     <App />
-   </Provider>,
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -41,3 +41,8 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('root')
 );
+
+// Enable React Dev Tools on local envs
+if (typeof window !== 'undefined') {
+  window.React = React;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,7 +4736,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -8316,6 +8316,13 @@ react-beautiful-dnd@^11.0.4:
     redux "^4.0.1"
     tiny-invariant "^1.0.4"
     use-memo-one "^1.1.0"
+
+react-click-outside@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  integrity sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
 
 react-csv@^1.0.14:
   version "1.0.14"


### PR DESCRIPTION
Currently, you have to manually close the projects modal. Now, you can just click outside of it.
