### PR TITLE
Add the ability to create a new ticket from the dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prettier": "^0.20.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-autocomplete": "^1.8.1",
     "react-beautiful-dnd": "^11.0.4",
     "react-csv": "^1.0.14",
     "react-dom": "^16.8.6",

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -26,9 +26,17 @@ class CreateTicket extends PureComponent {
   }
 
   getPhases = () => {
+    let phases = [];
+
     const deduplicatedTickets = this.props.tickets.filter((ticket, index, tix) => {
       return tix.findIndex(t => (t.id === ticket.id)) === index;
     });
+
+    if (deduplicatedTickets.length) {
+      deduplicatedTickets.map(ticket => {
+        phases.push(ticket.phase.path);
+      });
+    }
     
     this.setState({
       phases

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -8,6 +8,7 @@ class CreateTicket extends PureComponent {
     description: '',
     expanded: false,
     hasCompletedTicket: false,
+    initialDescription: '',
     phases: [],
     phaseValue: '',
     projects: [],
@@ -40,7 +41,7 @@ class CreateTicket extends PureComponent {
       project: { id: this.state.selectedProject[0].id },
       phase: { id: this.state.selectedPhase[0].id },
       budgetHours: this.state.budget,
-      initialDescription: '',
+      initialDescription: this.state.initialDescription,
     })
 
     // @todo allow service ticket creation
@@ -50,7 +51,7 @@ class CreateTicket extends PureComponent {
       company: { id: this.state.selectedProject[0].companyId },
       agreement: '', // where is this?
       budgetHours: this.state.budget,
-      initialDescription: '',
+      initialDescription: this.state.initialDescription,
     })
     
     if (this.state.ticketType === 'project') {
@@ -209,18 +210,19 @@ class CreateTicket extends PureComponent {
                   )}
                   {this.state.budget > 0 && (
                     <div>
-                      <label htmlFor="description">Description</label>
+                      <label htmlFor="initial-description">Description</label>
                       <textarea
-                        id="description"
+                        id="initial-description"
                         rows="4"
                         cols="50"
                         className="form-control"
-                        onChange={(e) => e.target.value.length > 5 && this.setState({ description: true })}
+                        placeholder="This is optional"
+                        onChange={(e) => e.target.value.length > 5 && this.setState({ initialDescription: e.target.value })}
                       >
                       </textarea>
                     </div>
                   )}
-                  {(this.state.summary && this.state.budget && this.state.description) && (
+                  {(this.state.summary && this.state.budget) && (
                     <button
                       type="button"
                       onClick={() => {

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -32,6 +32,23 @@ class CreateTicket extends PureComponent {
     if (prevProps.projects !== this.props.projects) {
       this.getProjects();      
     }
+
+    if (prevProps.selectedProject !== this.props.selectedProject) {
+      const { selectedProject } = this.props;
+      if (this.props.selectedProject['project.name']) {
+        this.resetTicketDetails();
+        this.getPhases(this.state.projects.filter(project => (
+          project.name === selectedProject['project.name'] &&
+          project.company.name === selectedProject['project.company']
+        )));
+
+        this.setState({
+          selectedProject: this.state.projects.filter(project => (
+            project.name === `${this.props.selectedProject['company.name']} — ${this.props.selectedProject['project.name']}`)
+          )
+        });
+      }
+    }
   }
 
   createNewTicket = () => {
@@ -80,11 +97,12 @@ class CreateTicket extends PureComponent {
     })
   }
 
-  getPhases = (selectedProject) => {
+  getPhases = () => {
     let phases = [];
+    const { selectedProject } = this.props;
 
     this.props.tickets.map(ticket => {
-      if (selectedProject[0].id === ticket.project.id) {
+      if (selectedProject['project.name'] === ticket.project.name && selectedProject['company.name'] === ticket.company.name) {
         phases.push({
           path: ticket.phase.path,
           phaseId: ticket.phase.id,
@@ -139,25 +157,11 @@ class CreateTicket extends PureComponent {
               <React.Fragment>
                 <div className="autocomplete-field">
                   <label htmlFor="projects">Project</label><br></br>
-                  <Autocomplete
+                  <input
                     id="projects"
-                    items={this.state.projects}
-                    getItemValue={item => item.name}
-                    shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                    renderItem={(item, highlighted) =>
-                      <div key={`${item.id}-${item.name}`}>
-                        {item.name}
-                      </div>
-                    }
-                    inputProps={{ className: "autocomplete-input" }}
+                    className="form-control"
+                    disabled="disabled"
                     value={`${this.props.selectedProject['company.name']} — ${this.props.selectedProject['project.name']}`}
-                    onChange={e => this.setState({ projectValue: e.target.value })}
-                    onSelect={value => {
-                      this.setState({
-                        projectValue: value,
-                        selectedProject: this.state.projects.filter(project => project.name === value),
-                      }, this.getPhases(this.state.projects.filter(project => project.name === value)))
-                    }}
                   />
                 </div>
                 <div className="autocomplete-field">

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -4,8 +4,14 @@ import Select from 'react-select';
 class CreateTicket extends PureComponent {
   state = {
     expanded: false,
-    ticketType: 'project'
+    ticketType: 'default',
+    phases: []
   }
+
+  componentDidMount = () => {
+    this.getPhases();
+  }
+  
 
   expandAddTicketForm = () => {
     this.setState({
@@ -17,6 +23,16 @@ class CreateTicket extends PureComponent {
     this.setState({
       ticketType: event.target.value
     })
+  }
+
+  getPhases = () => {
+    const deduplicatedTickets = this.props.tickets.filter((ticket, index, tix) => {
+      return tix.findIndex(t => (t.id === ticket.id)) === index;
+    });
+    
+    this.setState({
+      phases
+    });
   }
 
   render() {
@@ -35,6 +51,7 @@ class CreateTicket extends PureComponent {
           <form>
             <label htmlFor="type">Type</label>
             <select className="form-control" id="type" name="type" defaultValue={this.state.ticketType} onChange={this.selectTicketType}>
+              <option disabled value="default">Select Ticket Type</option>
               <option value="project">Project Ticket</option>
               <option value="service">Service Ticket</option>
             </select>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -265,10 +265,6 @@ class CreateTicket extends PureComponent {
                           </a>
                         )}
                       </p>
-                      <p>{`Project: ${this.state.projectValue}`}</p>
-                      <p>{`Phase: ${this.state.phaseValue}`}</p>
-                      <p>{`Budget: ${this.state.budget} hours`}</p>
-                      <p>{`Summary: ${this.state.summary}`}</p>
                       <button type="button" onClick={() => this.resetTicketDetails()}>Create another ticket</button>
                     </div>
                   ))}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -1,13 +1,21 @@
 import React, { PureComponent } from 'react';
+import Select from 'react-select';
 
 class CreateTicket extends PureComponent {
   state = {
     expanded: false,
+    ticketType: 'project'
   }
 
   expandAddTicketForm = () => {
     this.setState({
       expanded: !this.state.expanded
+    })
+  }
+
+  selectTicketType = event => {
+    this.setState({
+      ticketType: event.target.value
     })
   }
 
@@ -25,11 +33,16 @@ class CreateTicket extends PureComponent {
         </button>
         {this.state.expanded && (
           <form>
-            <label for="type">Type</label>
-            <select className="form-control" id="type" name="type">
-              <option value="project" selected="selected">Project Ticket</option>
+            <label htmlFor="type">Type</label>
+            <select className="form-control" id="type" name="type" defaultValue={this.state.ticketType} onChange={this.selectTicketType}>
+              <option value="project">Project Ticket</option>
               <option value="service">Service Ticket</option>
             </select>
+            {this.state.ticketType === 'project' ? (
+              console.log('project')
+            ) : (
+              console.log('service')
+            )}
           </form>
         )}
       </div>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -104,7 +104,7 @@ class CreateTicket extends PureComponent {
                     getItemValue={item => item.name}
                     shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     renderItem={(item, highlighted) =>
-                      <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
+                      <div key={item.id} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
                         {item.name}
                       </div>
                     }
@@ -128,7 +128,7 @@ class CreateTicket extends PureComponent {
                         getItemValue={item => item.path}
                         shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
                         renderItem={(item, highlighted) =>
-                          <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
+                          <div key={item.id} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
                             {item.path}
                           </div>
                         }
@@ -147,7 +147,12 @@ class CreateTicket extends PureComponent {
                   {this.state.hasSelectedPhase && (
                     <div>
                       <label htmlFor="summary">Summary</label>
-                      <input type="text" id="summary" onChange={() => this.setState({ hasSummary: true })}></input>
+                      <input
+                        className="form-control"
+                        type="text"
+                        id="summary"
+                        onChange={() => this.setState({ hasSummary: true })}
+                      ></input>
                     </div>
                   )}
                   {this.state.hasSummary && (
@@ -156,6 +161,7 @@ class CreateTicket extends PureComponent {
                       <input
                         type="number"
                         id="budget-hours"
+                        className="form-control"
                         onChange={(e) => this.setState({ budget: e.target.value })}
                       >
                       </input>
@@ -165,7 +171,11 @@ class CreateTicket extends PureComponent {
                   {this.state.budget > 0 && (
                     <div>
                       <label htmlFor="description">Description</label>
-                      <textarea id="description" 
+                      <textarea
+                        id="description"
+                        rows="4"
+                        cols="50"
+                        className="form-control"
                         onChange={(e) => {
                           if (e.target.value.length && e.target.value.length > 5) {
                             this.setState({ hasDescription: true })
@@ -174,8 +184,14 @@ class CreateTicket extends PureComponent {
                       </textarea>
                     </div>
                   )}
-                  {(this.state.hasSelectedProject && this.state.hasSelectedPhase && this.state.hasSummary && this.state.hasBudgetHours && this.state.hasDescription) && (
-                    <button type="button" onClick={() => this.setState({ hasCompletedTicket: true })}>Create Ticket</button>
+                  {(this.state.hasSelectedProject && this.state.hasSelectedPhase && this.state.hasSummary && this.state.budget && this.state.hasDescription) && (
+                    <button
+                      type="button"
+                      onClick={() => this.setState({ hasCompletedTicket: true })}
+                      className="btn btn-default"
+                    >
+                      Create Ticket
+                    </button>
                   )}
                   {(this.state.hasCompletedTicket && (
                     <div>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -90,7 +90,7 @@ class CreateTicket extends PureComponent {
           <form>
             <label htmlFor="type">Type</label>
             <select className="form-control" id="type" name="type" defaultValue={this.state.ticketType} onChange={this.selectTicketType}>
-              <option disabled value="default">Select Ticket Type</option>
+              <option disabled value="default"> - Select Ticket Type - </option>
               <option value="project">Project Ticket</option>
               <option value="service">Service Ticket</option>
             </select>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -194,6 +194,7 @@ class CreateTicket extends PureComponent {
                         id="summary"
                         onChange={(e) => this.setState({ summary: e.target.value })}
                         required
+                        autoComplete="off"
                       ></input>
                     </div>
                   )}
@@ -210,6 +211,7 @@ class CreateTicket extends PureComponent {
                         min="0"
                         step="0.25"
                         placeholder="1"
+                        autoComplete="off"
                       >
                       </input>
                       {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -255,13 +255,15 @@ class CreateTicket extends PureComponent {
                   {(this.state.hasCompletedTicket && (
                     <div>
                       <p>You've created a new ticket:
-                      <a
-                        href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {` #${this.state.newTicketId}`}
-                        </a>
+                        {this.state.newTicketId && (
+                          <a
+                            href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {` #${this.state.newTicketId}`}
+                          </a>
+                        )}
                       </p>
                       <p>{`Project: ${this.state.projectValue}`}</p>
                       <p>{`Phase: ${this.state.phaseValue}`}</p>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -159,7 +159,13 @@ class CreateTicket extends PureComponent {
                   {this.state.hasBudgetHours && (
                     <div>
                       <label htmlFor="description">Description</label>
-                      <textarea id="description" onChange={() => this.setState({ hasDescription: true })}></textarea>
+                      <textarea id="description" 
+                        onChange={(e) => {
+                          if (e.target.value.length && e.target.value.length > 5) {
+                            this.setState({ hasDescription: true })
+                          }
+                        }}>
+                      </textarea>
                     </div>
                   )}
                   {(this.state.hasSelectedProject && this.state.hasSelectedPhase && this.state.hasSummary && this.state.hasBudgetHours && this.state.hasDescription) && (

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -97,7 +97,7 @@ class CreateTicket extends PureComponent {
             {this.state.ticketType === 'project' ? (
               <React.Fragment>
                 <div>
-                  <label htmlFor="projects">Project</label>
+                  <label htmlFor="projects">Project</label><br></br>
                   <Autocomplete
                     id="projects"
                     items={this.state.projects}
@@ -108,6 +108,7 @@ class CreateTicket extends PureComponent {
                         {item.name}
                       </div>
                     }
+                    inputProps={{ className: "btn btn-default" }}
                     value={this.state.projectValue}
                     onChange={e => this.setState({ projectValue: e.target.value })}
                     onSelect={value => {
@@ -121,7 +122,7 @@ class CreateTicket extends PureComponent {
                 <div>
                   {this.state.hasSelectedProject && (
                     <React.Fragment>
-                      <label htmlFor="phases">Phase</label>
+                      <label htmlFor="phases">Phase</label><br></br>
                       <Autocomplete
                         id="phases"
                         items={this.state.phases}
@@ -133,6 +134,7 @@ class CreateTicket extends PureComponent {
                           </div>
                         }
                         value={this.state.phaseValue}
+                        inputProps={{ className: "btn btn-default" }}
                         onChange={e => this.setState({ phaseValue: e.target.value })}
                         onSelect={value => {
                           this.setState({

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -144,7 +144,7 @@ class CreateTicket extends PureComponent {
                     getItemValue={item => item.name}
                     shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     renderItem={(item, highlighted) =>
-                      <div key={`${item.id}-${item.name}`} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
+                      <div key={`${item.id}-${item.name}`}>
                         {item.name}
                       </div>
                     }
@@ -168,7 +168,7 @@ class CreateTicket extends PureComponent {
                         getItemValue={item => item.path}
                         shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
                         renderItem={(item, highlighted) =>
-                          <div key={`${item.id}-${item.name}`} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
+                          <div key={`${item.id}-${item.name}`}>
                             {item.path}
                           </div>
                         }
@@ -192,6 +192,7 @@ class CreateTicket extends PureComponent {
                         type="text"
                         id="summary"
                         onChange={(e) => this.setState({ summary: e.target.value })}
+                        required
                       ></input>
                     </div>
                   )}
@@ -203,6 +204,7 @@ class CreateTicket extends PureComponent {
                         id="budget-hours"
                         className="form-control"
                         onChange={(e) => this.setState({ budget: e.target.value })}
+                        required
                       >
                       </input>
                       {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}
@@ -229,7 +231,7 @@ class CreateTicket extends PureComponent {
                         this.setState({ hasCompletedTicket: true })
                         this.createNewTicket();
                       }}
-                      className="btn btn-default"
+                      className="btn btn-submit"
                     >
                       Create Ticket
                     </button>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -1,3 +1,4 @@
+import Modal from 'react-modal';
 import React, { PureComponent } from 'react';
 import Autocomplete from 'react-autocomplete';
 import { createTicket } from '../../helpers/cw';
@@ -135,7 +136,6 @@ class CreateTicket extends PureComponent {
   resetTicketDetails = () => {
     this.setState({
       ...this.emptyTicketState,
-      expanded: true
     });
   }
 
@@ -152,7 +152,13 @@ class CreateTicket extends PureComponent {
             {this.state.expanded ? '—' : '＋'} Create Ticket
           </button>
         )}
-        {this.state.expanded && (
+        <Modal
+          contentLabel="Create Ticket Modal"
+          isOpen={this.state.expanded}
+          overlayClassName="modal-overlay ticket-modal"
+          onRequestClose={this.expandAddTicketForm}
+          shouldCloseOnOverlayClick={true}
+        >
           <form>
               <React.Fragment>
                 <div className="autocomplete-field">
@@ -178,7 +184,7 @@ class CreateTicket extends PureComponent {
                           </div>
                         }
                         value={this.state.phaseValue}
-                        inputProps={{ className: "autocomplete-input" }}
+                        inputProps={{ className: "autocomplete-input form-control" }}
                         onChange={e => this.setState({ phaseValue: e.target.value })}
                         onSelect={value => {
                           this.setState({
@@ -210,7 +216,6 @@ class CreateTicket extends PureComponent {
                         id="budget-hours"
                         className="form-control"
                         onChange={(e) => this.setState({ budget: e.target.value })}
-                        required
                         required
                         min="0"
                         step="0.25"
@@ -250,7 +255,7 @@ class CreateTicket extends PureComponent {
                   {(this.state.hasCompletedTicket && (
                     <div>
                       <p>You've created a new ticket:
-                       <a
+                      <a
                         href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
                         target="_blank"
                         rel="noopener noreferrer"
@@ -267,7 +272,7 @@ class CreateTicket extends PureComponent {
                   ))}
               </React.Fragment>
           </form>
-        )}
+        </Modal>
       </div>
     )
   }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -14,9 +14,9 @@ class CreateTicket extends PureComponent {
   render() {
     
     return (
-      <React.Fragment>
+      <div className="create-ticket-form">
         <button
-          className="btn btn-default btn-lg"
+          className="btn btn-default btn-lg expand"
           type="button"
           aria-label="add"
           onClick={() => this.expandAddTicketForm()}
@@ -32,7 +32,7 @@ class CreateTicket extends PureComponent {
             </select>
           </form>
         )}
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -39,7 +39,7 @@ class CreateTicket extends PureComponent {
       recordType: 'ProjectTicket',
       company: { id: this.state.selectedProject[0].companyId },
       project: { id: this.state.selectedProject[0].id },
-      phase: { id: this.state.selectedPhase[0].id },
+      phase: { id: this.state.selectedPhase[0].phaseId },
       budgetHours: this.state.budget,
       initialDescription: this.state.initialDescription,
     })
@@ -82,7 +82,8 @@ class CreateTicket extends PureComponent {
       if (selectedProject[0].id === ticket.project.id) {
         phases.push({
           path: ticket.phase.path,
-          id: ticket.phase.id
+          phaseId: ticket.phase.id,
+          ticketId: ticket.id
         });
       }
     });
@@ -169,7 +170,7 @@ class CreateTicket extends PureComponent {
                         getItemValue={item => item.path}
                         shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
                         renderItem={(item, highlighted) =>
-                          <div key={`${item.id}-${item.name}`}>
+                          <div key={`${item.phaseId}-${item.ticketId}`}>
                             {item.path}
                           </div>
                         }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -8,6 +8,8 @@ class CreateTicket extends PureComponent {
     phases: [],
     projects: [],
     value: '',
+    phaseValue: '',
+    projectValue: '',
     hasSelectedProject: false,
     hasSelectedPhase: false
   }
@@ -15,6 +17,13 @@ class CreateTicket extends PureComponent {
   componentDidMount = () => {
     this.getPhases();
     this.getProjects();
+  }
+
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.projects !== this.props.projects) {
+      this.getPhases();
+      this.getProjects();      
+    }
   }
   
 
@@ -85,8 +94,8 @@ class CreateTicket extends PureComponent {
                 <div>
                   <Autocomplete
                     items={this.state.projects}
-                    shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     getItemValue={item => item.name}
+                    shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     renderItem={(item, highlighted) =>
                       <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
                         {item.name}
@@ -103,24 +112,26 @@ class CreateTicket extends PureComponent {
                   />
                 </div>
                 <div>
-                  <Autocomplete
-                    items={this.state.phases}
-                    shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                    getItemValue={item => item.phase}
-                    renderItem={(item, highlighted) =>
-                      <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
-                        {item.path}
-                      </div>
-                    }
-                    value={this.state.phaseValue}
-                    onChange={e => this.setState({ phaseValue: e.target.value })}
-                    onSelect={value => {
-                      this.setState({
-                        phaseValue: value,
-                        hasSelectedPhase: true
-                      })
-                    }}
-                  />
+                  {this.state.hasSelectedProject && (
+                    <Autocomplete
+                      items={this.state.phases}
+                      getItemValue={item => item.path}
+                      shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                      renderItem={(item, highlighted) =>
+                        <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
+                          {item.path}
+                        </div>
+                      }
+                      value={this.state.phaseValue}
+                      onChange={e => this.setState({ phaseValue: e.target.value })}
+                      onSelect={value => {
+                        this.setState({
+                          phaseValue: value,
+                          hasSelectedPhase: true
+                        })
+                      }}
+                    />
+                  )}
                 </div>
               </React.Fragment>
             ) : (

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -5,14 +5,31 @@ class CreateTicket extends PureComponent {
     expanded: false,
   }
 
+  expandAddTicketForm = () => {
+    this.setState({
+      expanded: true
+    })
+  }
+
   render() {
     
     return (
       <React.Fragment>
-        <button className="btn btn-default btn-lg" type="button" aria-label="add">＋ Create Ticket</button>
+        <button
+          className="btn btn-default btn-lg"
+          type="button"
+          aria-label="add"
+          onClick={() => this.expandAddTicketForm()}
+        >
+          ＋ Create Ticket
+        </button>
         {this.state.expanded && (
           <form>
-            
+            <label for="type">Type</label>
+            <select className="form-control" id="type" name="type">
+              <option value="volvo">Project Ticket</option>
+              <option value="saab">Service Ticket</option>
+            </select>
           </form>
         )}
       </React.Fragment>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -1,13 +1,20 @@
 import React, { PureComponent } from 'react';
 
 class CreateTicket extends PureComponent {
+  state = {
+    expanded: false,
+  }
+
   render() {
+    
     return (
       <React.Fragment>
         <button className="btn btn-default btn-lg" type="button" aria-label="add">＋ Create Ticket</button>
-        <div>
-          
-        </div>
+        {this.state.expanded && (
+          <form>
+            
+          </form>
+        )}
       </React.Fragment>
     )
   }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -144,7 +144,7 @@ class CreateTicket extends PureComponent {
       <div className="create-ticket-form">
         {this.props.selectedProject['company.name'] && (
           <button
-            className="btn btn-default btn-lg expand"
+            className="btn btn-default btn-md btn-expand"
             type="button"
             aria-label="add"
             onClick={() => this.expandAddTicketForm()}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -33,7 +33,7 @@ class CreateTicket extends PureComponent {
   }
 
   createNewTicket = () => {
-    const ticketDetails = ({
+    const projectTicketDetails = ({
       summary: this.state.summary,
       recordType: 'ProjectTicket',
       company: { id: this.state.selectedProject[0].companyId },
@@ -43,8 +43,23 @@ class CreateTicket extends PureComponent {
       initialDescription: '',
     })
 
-    createTicket(ticketDetails);
-  }
+    const serviceTicketDetails = ({
+      summary: this.state.summary,
+      recordType: 'ServiceTicket',
+      company: { id: this.state.selectedProject[0].companyId },
+      agreement: { id: this.state.selectedProject[0].id },
+      budgetHours: this.state.budget,
+      initialDescription: '',
+    })
+    
+    if (this.state.ticketType === 'project') {
+      createTicket(projectTicketDetails);
+    }
+
+    if (this.state.ticketType === 'service') {
+      createTicket(serviceTicketDetails);
+    }
+  };
 
   expandAddTicketForm = () => {
     this.setState({

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -1,0 +1,16 @@
+import React, { PureComponent } from 'react';
+
+class CreateTicket extends PureComponent {
+  render() {
+    return (
+      <React.Fragment>
+        <button className="btn btn-default btn-lg" type="button" aria-label="add">＋ Create Ticket</button>
+        <div>
+          
+        </div>
+      </React.Fragment>
+    )
+  }
+}
+
+export default CreateTicket;

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -146,7 +146,6 @@ class CreateTicket extends PureComponent {
           <button
             className="btn btn-default btn-md btn-expand"
             type="button"
-            aria-label="add"
             onClick={() => this.expandAddTicketForm()}
           >
             {this.state.expanded ? '—' : '＋'} Create Ticket
@@ -160,115 +159,111 @@ class CreateTicket extends PureComponent {
           shouldCloseOnOverlayClick={true}
         >
           <form>
-              <React.Fragment>
-                <div className="autocomplete-field">
-                  <label htmlFor="projects">Project</label><br></br>
-                  <input
-                    id="projects"
-                    className="form-control"
-                    disabled="disabled"
-                    value={`${this.props.selectedProject['company.name']} — ${this.props.selectedProject['project.name']}`}
-                  />
-                </div>
-                <div className="autocomplete-field">
-                    <React.Fragment>
-                      <label htmlFor="phases">Phase</label><br></br>
-                      <Autocomplete
-                        id="phases"
-                        items={this.state.phases}
-                        getItemValue={item => item.path}
-                        shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                        renderItem={(item, highlighted) =>
-                          <div key={`${item.phaseId}-${item.ticketId}`}>
-                            {item.path}
-                          </div>
-                        }
-                        value={this.state.phaseValue}
-                        inputProps={{ className: "autocomplete-input form-control" }}
-                        onChange={e => this.setState({ phaseValue: e.target.value })}
-                        onSelect={value => {
-                          this.setState({
-                            phaseValue: value,
-                            selectedPhase: this.state.phases.filter(phase => phase.path === value),
-                          })
-                        }}
-                      />
-                    </React.Fragment>
-                </div>
-                  {this.state.phaseValue && (
-                    <div>
-                      <label htmlFor="summary">Summary</label>
-                      <input
-                        className="form-control"
-                        type="text"
-                        id="summary"
-                        onChange={(e) => this.setState({ summary: e.target.value })}
-                        required
-                        autoComplete="off"
-                      ></input>
-                    </div>
-                  )}
-                  {this.state.summary && (
-                    <div>
-                      <label htmlFor="budget-hours">Budget Hours</label>
-                      <input
-                        type="number"
-                        id="budget-hours"
-                        className="form-control"
-                        onChange={(e) => this.setState({ budget: e.target.value })}
-                        required
-                        min="0"
-                        step="0.25"
-                        placeholder="1"
-                        autoComplete="off"
-                      >
-                      </input>
-                      {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}
-                    </div>
-                  )}
-                  {this.state.budget > 0 && (
-                    <div>
-                      <label htmlFor="initial-description">Description</label>
-                      <textarea
-                        id="initial-description"
-                        rows="4"
-                        cols="50"
-                        className="form-control"
-                        placeholder="This is optional"
-                        onChange={(e) => e.target.value.length > 5 && this.setState({ initialDescription: e.target.value })}
-                      >
-                      </textarea>
-                    </div>
-                  )}
-                  {(this.state.summary && this.state.budget) && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        this.setState({ hasCompletedTicket: true })
-                        this.createNewTicket();
-                      }}
-                      className="btn btn-submit"
+            <div className="autocomplete-field">
+              <label htmlFor="projects">Project</label><br></br>
+              <input
+                id="projects"
+                className="form-control"
+                disabled="disabled"
+                value={`${this.props.selectedProject['company.name']} — ${this.props.selectedProject['project.name']}`}
+              />
+            </div>
+            <div className="autocomplete-field">
+              <label htmlFor="phases">Phase</label><br></br>
+              <Autocomplete
+                id="phases"
+                items={this.state.phases}
+                getItemValue={item => item.path}
+                shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                renderItem={(item, highlighted) =>
+                  <div key={`${item.phaseId}-${item.ticketId}`}>
+                    {item.path}
+                  </div>
+                }
+                value={this.state.phaseValue}
+                inputProps={{ className: "autocomplete-input form-control" }}
+                onChange={e => this.setState({ phaseValue: e.target.value })}
+                onSelect={value => {
+                  this.setState({
+                    phaseValue: value,
+                    selectedPhase: this.state.phases.filter(phase => phase.path === value),
+                  })
+                }}
+              />
+            </div>
+            {this.state.phaseValue && (
+              <div>
+                <label htmlFor="summary">Summary</label>
+                <input
+                  className="form-control"
+                  type="text"
+                  id="summary"
+                  onChange={(e) => this.setState({ summary: e.target.value })}
+                  required
+                  autoComplete="off"
+                ></input>
+              </div>
+            )}
+            {this.state.summary && (
+              <div>
+                <label htmlFor="budget-hours">Budget Hours</label>
+                <input
+                  type="number"
+                  id="budget-hours"
+                  className="form-control"
+                  onChange={(e) => this.setState({ budget: e.target.value })}
+                  required
+                  min="0"
+                  step="0.25"
+                  placeholder="1"
+                  autoComplete="off"
+                >
+                </input>
+                {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}
+              </div>
+            )}
+            {this.state.budget > 0 && (
+              <div>
+                <label htmlFor="initial-description">Description</label>
+                <textarea
+                  id="initial-description"
+                  rows="4"
+                  cols="50"
+                  className="form-control"
+                  placeholder="This is optional"
+                  onChange={(e) => e.target.value.length > 5 && this.setState({ initialDescription: e.target.value })}
+                >
+                </textarea>
+              </div>
+            )}
+            {(this.state.summary && this.state.budget) && (
+              <button
+                type="button"
+                onClick={() => {
+                  this.setState({ hasCompletedTicket: true })
+                  this.createNewTicket();
+                }}
+                className="btn btn-submit"
+              >
+                Create Ticket
+              </button>
+            )}
+            {(this.state.hasCompletedTicket && (
+              <div>
+                <p>You've created a new ticket:
+                  {this.state.newTicketId && (
+                    <a
+                      href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
-                      Create Ticket
-                    </button>
+                      {` #${this.state.newTicketId}`}
+                    </a>
                   )}
-                  {(this.state.hasCompletedTicket && (
-                    <div>
-                      <p>You've created a new ticket:
-                        {this.state.newTicketId && (
-                          <a
-                            href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {` #${this.state.newTicketId}`}
-                          </a>
-                        )}
-                      </p>
-                      <button type="button" onClick={() => this.resetTicketDetails()}>Create another ticket</button>
-                    </div>
-                  ))}
-              </React.Fragment>
+                </p>
+                <button type="button" className="btn btn-default" onClick={() => this.resetTicketDetails()}>Create another ticket</button>
+              </div>
+            ))}
           </form>
         </Modal>
       </div>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -6,11 +6,13 @@ class CreateTicket extends PureComponent {
     expanded: false,
     ticketType: 'default',
     phases: [],
+    projects: [],
     value: ''
   }
 
   componentDidMount = () => {
     this.getPhases();
+    this.getProjects();
   }
   
 
@@ -41,6 +43,21 @@ class CreateTicket extends PureComponent {
     });
   }
 
+  getProjects = () => {
+    let projects = [];
+
+    this.props.projects.map(project => {
+      projects.push({
+        name: project.company.name,
+        id: project.company.id
+      });
+    });
+    
+    this.setState({
+      projects
+    });
+  }
+
   render() {
     
     return (
@@ -63,15 +80,15 @@ class CreateTicket extends PureComponent {
             </select>
             {this.state.ticketType === 'project' ? (
               <Autocomplete
-                items={this.state.phases}
-                shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                getItemValue={item => item.path}
+                items={this.state.projects}
+                shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                getItemValue={item => item.name}
                 renderItem={(item, highlighted) =>
                   <div
                     key={item.id}
                     style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
                   >
-                    {item.path}
+                    {item.name}
                   </div>
                 }
                 value={this.state.value}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -43,11 +43,12 @@ class CreateTicket extends PureComponent {
       initialDescription: '',
     })
 
+    // @todo allow service ticket creation
     const serviceTicketDetails = ({
       summary: this.state.summary,
       recordType: 'ServiceTicket',
       company: { id: this.state.selectedProject[0].companyId },
-      agreement: { id: this.state.selectedProject[0].id },
+      agreement: '', // where is this?
       budgetHours: this.state.budget,
       initialDescription: '',
     })
@@ -134,7 +135,7 @@ class CreateTicket extends PureComponent {
             </select>
             {this.state.ticketType === 'project' ? (
               <React.Fragment>
-                <div>
+                <div className="autocomplete-field">
                   <label htmlFor="projects">Project</label><br></br>
                   <Autocomplete
                     id="projects"
@@ -146,7 +147,7 @@ class CreateTicket extends PureComponent {
                         {item.name}
                       </div>
                     }
-                    inputProps={{ className: "btn btn-default" }}
+                    inputProps={{ className: "autocomplete-input" }}
                     value={this.state.projectValue}
                     onSelect={value => {
                       this.setState({
@@ -156,7 +157,7 @@ class CreateTicket extends PureComponent {
                     }}
                   />
                 </div>
-                <div>
+                <div className="autocomplete-field">
                   {this.state.projectValue && (
                     <React.Fragment>
                       <label htmlFor="phases">Phase</label><br></br>
@@ -171,7 +172,7 @@ class CreateTicket extends PureComponent {
                           </div>
                         }
                         value={this.state.phaseValue}
-                        inputProps={{ className: "btn btn-default" }}
+                        inputProps={{ className: "autocomplete-input" }}
                         onSelect={value => {
                           this.setState({
                             phaseValue: value,

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -124,14 +124,16 @@ class CreateTicket extends PureComponent {
   render() {
     return (
       <div className="create-ticket-form">
-        <button
-          className="btn btn-default btn-lg expand"
-          type="button"
-          aria-label="add"
-          onClick={() => this.expandAddTicketForm()}
-        >
-          {this.state.expanded ? '—' : '＋'} Create Ticket
-        </button>
+        {this.props.selectedProject['company.name'] && (
+          <button
+            className="btn btn-default btn-lg expand"
+            type="button"
+            aria-label="add"
+            onClick={() => this.expandAddTicketForm()}
+          >
+            {this.state.expanded ? '—' : '＋'} Create Ticket
+          </button>
+        )}
         {this.state.expanded && (
           <form>
               <React.Fragment>
@@ -148,7 +150,7 @@ class CreateTicket extends PureComponent {
                       </div>
                     }
                     inputProps={{ className: "autocomplete-input" }}
-                    value={this.state.projectValue}
+                    value={`${this.props.selectedProject['company.name']} — ${this.props.selectedProject['project.name']}`}
                     onChange={e => this.setState({ projectValue: e.target.value })}
                     onSelect={value => {
                       this.setState({
@@ -159,7 +161,6 @@ class CreateTicket extends PureComponent {
                   />
                 </div>
                 <div className="autocomplete-field">
-                  {this.state.projectValue && (
                     <React.Fragment>
                       <label htmlFor="phases">Phase</label><br></br>
                       <Autocomplete
@@ -183,7 +184,6 @@ class CreateTicket extends PureComponent {
                         }}
                       />
                     </React.Fragment>
-                  )}
                 </div>
                   {this.state.phaseValue && (
                     <div>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -17,7 +17,7 @@ class CreateTicket extends PureComponent {
     selectedPhase: {},
     selectedProject: {},
     summary: '',
-    ticketType: 'default',
+    ticketType: 'project',
   }
 
   state = {
@@ -134,13 +134,6 @@ class CreateTicket extends PureComponent {
         </button>
         {this.state.expanded && (
           <form>
-            <label htmlFor="type">Type</label>
-            <select className="form-control" id="type" name="type" defaultValue={this.state.ticketType} onChange={this.selectTicketType}>
-              <option disabled value="default"> - Select Ticket Type - </option>
-              <option value="project">Project Ticket</option>
-              <option value="service">Service Ticket</option>
-            </select>
-            {this.state.ticketType === 'project' ? (
               <React.Fragment>
                 <div className="autocomplete-field">
                   <label htmlFor="projects">Project</label><br></br>
@@ -246,7 +239,7 @@ class CreateTicket extends PureComponent {
                   )}
                   {(this.state.hasCompletedTicket && (
                     <div>
-                      <p>You've created a new {`${this.state.ticketType}`} ticket:
+                      <p>You've created a new ticket:
                        <a
                         href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
                         target="_blank"
@@ -263,9 +256,6 @@ class CreateTicket extends PureComponent {
                     </div>
                   ))}
               </React.Fragment>
-            ) : (
-              console.log('service')
-            )}
           </form>
         )}
       </div>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -27,8 +27,8 @@ class CreateTicket extends PureComponent {
           <form>
             <label for="type">Type</label>
             <select className="form-control" id="type" name="type">
-              <option value="volvo">Project Ticket</option>
-              <option value="saab">Service Ticket</option>
+              <option value="project" selected="selected">Project Ticket</option>
+              <option value="service">Service Ticket</option>
             </select>
           </form>
         )}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -9,6 +9,7 @@ class CreateTicket extends PureComponent {
     expanded: false,
     hasCompletedTicket: false,
     initialDescription: '',
+    newTicketId: '',
     phases: [],
     phaseValue: '',
     projects: [],
@@ -55,7 +56,11 @@ class CreateTicket extends PureComponent {
     })
     
     if (this.state.ticketType === 'project') {
-      createTicket(projectTicketDetails);
+      createTicket(projectTicketDetails).then(res => {
+        this.setState({
+          newTicketId: res.result.id
+        })
+      })
     }
 
     if (this.state.ticketType === 'service') {
@@ -241,7 +246,15 @@ class CreateTicket extends PureComponent {
                   )}
                   {(this.state.hasCompletedTicket && (
                     <div>
-                      <p>You've created a new <strong>{`${this.state.ticketType}`}</strong> ticket: {'ticketNumber'}</p>
+                      <p>You've created a new {`${this.state.ticketType}`} ticket:
+                       <a
+                        href={process.env.REACT_APP_CONNECTWISE_SERVER_URL + `/services/system_io/Service/fv_sr100_request.rails?service_recid=&${this.state.newTicketId}companyName=sd`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {` #${this.state.newTicketId}`}
+                        </a>
+                      </p>
                       <p>{`Project: ${this.state.projectValue}`}</p>
                       <p>{`Phase: ${this.state.phaseValue}`}</p>
                       <p>{`Budget: ${this.state.budget} hours`}</p>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -88,10 +88,7 @@ class CreateTicket extends PureComponent {
                     shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     getItemValue={item => item.name}
                     renderItem={(item, highlighted) =>
-                      <div
-                        key={item.id}
-                        style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
-                      >
+                      <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
                         {item.name}
                       </div>
                     }
@@ -111,10 +108,7 @@ class CreateTicket extends PureComponent {
                     shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     getItemValue={item => item.phase}
                     renderItem={(item, highlighted) =>
-                      <div
-                        key={item.id}
-                        style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
-                      >
+                      <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
                         {item.path}
                       </div>
                     }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -13,7 +13,6 @@ class CreateTicket extends PureComponent {
     hasSelectedProject: false,
     hasSelectedPhase: false,
     hasSummary: false,
-    hasBudgetHours: false,
     hasDescription: false,
     summary: '',
     budget: '',
@@ -154,10 +153,16 @@ class CreateTicket extends PureComponent {
                   {this.state.hasSummary && (
                     <div>
                       <label htmlFor="budget-hours">Budget Hours</label>
-                      <input type="number" id="budget-hours" onChange={() => this.setState({ hasBudgetHours: true })}></input>
+                      <input
+                        type="number"
+                        id="budget-hours"
+                        onChange={(e) => this.setState({ budget: e.target.value })}
+                      >
+                      </input>
+                      {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}
                     </div>
                   )}
-                  {this.state.hasBudgetHours && (
+                  {this.state.budget > 0 && (
                     <div>
                       <label htmlFor="description">Description</label>
                       <textarea id="description" 

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -142,7 +142,7 @@ class CreateTicket extends PureComponent {
                     getItemValue={item => item.name}
                     shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
                     renderItem={(item, highlighted) =>
-                      <div key={item.id} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
+                      <div key={`${item.id}-${item.name}`} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
                         {item.name}
                       </div>
                     }
@@ -166,7 +166,7 @@ class CreateTicket extends PureComponent {
                         getItemValue={item => item.path}
                         shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
                         renderItem={(item, highlighted) =>
-                          <div key={item.id} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
+                          <div key={`${item.id}-${item.name}`} style={{ backgroundColor: highlighted ? '#f5f5f5' : 'transparent'}}>
                             {item.path}
                           </div>
                         }

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -206,6 +206,10 @@ class CreateTicket extends PureComponent {
                         className="form-control"
                         onChange={(e) => this.setState({ budget: e.target.value })}
                         required
+                        required
+                        min="0"
+                        step="0.25"
+                        placeholder="1"
                       >
                       </input>
                       {this.state.budget > 10 && (<p>Warning: This is a higher than normal budget</p>)}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -150,6 +150,7 @@ class CreateTicket extends PureComponent {
                     }
                     inputProps={{ className: "autocomplete-input" }}
                     value={this.state.projectValue}
+                    onChange={e => this.setState({ projectValue: e.target.value })}
                     onSelect={value => {
                       this.setState({
                         projectValue: value,
@@ -174,6 +175,7 @@ class CreateTicket extends PureComponent {
                         }
                         value={this.state.phaseValue}
                         inputProps={{ className: "autocomplete-input" }}
+                        onChange={e => this.setState({ phaseValue: e.target.value })}
                         onSelect={value => {
                           this.setState({
                             phaseValue: value,

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -7,7 +7,9 @@ class CreateTicket extends PureComponent {
     ticketType: 'default',
     phases: [],
     projects: [],
-    value: ''
+    value: '',
+    hasSelectedProject: false,
+    hasSelectedPhase: false
   }
 
   componentDidMount = () => {
@@ -79,22 +81,54 @@ class CreateTicket extends PureComponent {
               <option value="service">Service Ticket</option>
             </select>
             {this.state.ticketType === 'project' ? (
-              <Autocomplete
-                items={this.state.projects}
-                shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                getItemValue={item => item.name}
-                renderItem={(item, highlighted) =>
-                  <div
-                    key={item.id}
-                    style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
-                  >
-                    {item.name}
-                  </div>
-                }
-                value={this.state.value}
-                onChange={e => this.setState({ value: e.target.value })}
-                onSelect={value => this.setState({ value })}
-              />
+              <React.Fragment>
+                <div>
+                  <Autocomplete
+                    items={this.state.projects}
+                    shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                    getItemValue={item => item.name}
+                    renderItem={(item, highlighted) =>
+                      <div
+                        key={item.id}
+                        style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
+                      >
+                        {item.name}
+                      </div>
+                    }
+                    value={this.state.projectValue}
+                    onChange={e => this.setState({ projectValue: e.target.value })}
+                    onSelect={value => {
+                      this.setState({
+                        projectValue: value,
+                        hasSelectedProject: true
+                      })
+                    }}
+                  />
+                </div>
+                <div>
+                  <Autocomplete
+                    items={this.state.phases}
+                    shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                    getItemValue={item => item.phase}
+                    renderItem={(item, highlighted) =>
+                      <div
+                        key={item.id}
+                        style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
+                      >
+                        {item.path}
+                      </div>
+                    }
+                    value={this.state.phaseValue}
+                    onChange={e => this.setState({ phaseValue: e.target.value })}
+                    onSelect={value => {
+                      this.setState({
+                        phaseValue: value,
+                        hasSelectedPhase: true
+                      })
+                    }}
+                  />
+                </div>
+              </React.Fragment>
             ) : (
               console.log('service')
             )}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -17,6 +17,8 @@ class CreateTicket extends PureComponent {
     hasDescription: false,
     summary: '',
     budget: '',
+    newTicketDetails: '',
+    hasCompletedTicket: false,
   }
 
   componentDidMount = () => {
@@ -75,7 +77,6 @@ class CreateTicket extends PureComponent {
   }
 
   render() {
-    
     return (
       <div className="create-ticket-form">
         <button
@@ -169,8 +170,18 @@ class CreateTicket extends PureComponent {
                     </div>
                   )}
                   {(this.state.hasSelectedProject && this.state.hasSelectedPhase && this.state.hasSummary && this.state.hasBudgetHours && this.state.hasDescription) && (
-                    <button type="submit">Create Ticket</button>
+                    <button type="button" onClick={() => this.setState({ hasCompletedTicket: true })}>Create Ticket</button>
                   )}
+                  {(this.state.hasCompletedTicket && (
+                    <div>
+                      <p>You've created a new <strong>{`${this.state.ticketType}`}</strong> ticket</p>
+                      <p>{`Project: ${this.state.projectValue}`}</p>
+                      <p>{`Phase: ${this.state.phaseValue}`}</p>
+                      <p>{`Budget: ${this.state.budget}`}</p>
+                      <p>{`Summary: ${this.state.summary}`}</p>
+                      <p>Ticket <strong>{`${'ticketNumber'}`}</strong></p>
+                    </div>
+                  ))}
               </React.Fragment>
             ) : (
               console.log('service')

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
-import Select from 'react-select';
+import Autocomplete from 'react-autocomplete';
 
 class CreateTicket extends PureComponent {
   state = {
     expanded: false,
     ticketType: 'default',
-    phases: []
+    phases: [],
+    value: ''
   }
 
   componentDidMount = () => {
@@ -28,15 +29,12 @@ class CreateTicket extends PureComponent {
   getPhases = () => {
     let phases = [];
 
-    const deduplicatedTickets = this.props.tickets.filter((ticket, index, tix) => {
-      return tix.findIndex(t => (t.id === ticket.id)) === index;
-    });
-
-    if (deduplicatedTickets.length) {
-      deduplicatedTickets.map(ticket => {
-        phases.push(ticket.phase.path);
+    this.props.tickets.map(ticket => {
+      phases.push({
+        path: ticket.phase.path,
+        id: ticket.id
       });
-    }
+    });
     
     this.setState({
       phases
@@ -64,7 +62,22 @@ class CreateTicket extends PureComponent {
               <option value="service">Service Ticket</option>
             </select>
             {this.state.ticketType === 'project' ? (
-              console.log('project')
+              <Autocomplete
+                items={this.state.phases}
+                shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                getItemValue={item => item.path}
+                renderItem={(item, highlighted) =>
+                  <div
+                    key={item.id}
+                    style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}
+                  >
+                    {item.path}
+                  </div>
+                }
+                value={this.state.value}
+                onChange={e => this.setState({ value: e.target.value })}
+                onSelect={value => this.setState({ value })}
+              />
             ) : (
               console.log('service')
             )}

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -162,6 +162,9 @@ class CreateTicket extends PureComponent {
                       <textarea id="description" onChange={() => this.setState({ hasDescription: true })}></textarea>
                     </div>
                   )}
+                  {(this.state.hasSelectedProject && this.state.hasSelectedPhase && this.state.hasSummary && this.state.hasBudgetHours && this.state.hasDescription) && (
+                    <button type="submit">Create Ticket</button>
+                  )}
               </React.Fragment>
             ) : (
               console.log('service')

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -7,7 +7,7 @@ class CreateTicket extends PureComponent {
 
   expandAddTicketForm = () => {
     this.setState({
-      expanded: true
+      expanded: !this.state.expanded
     })
   }
 
@@ -21,7 +21,7 @@ class CreateTicket extends PureComponent {
           aria-label="add"
           onClick={() => this.expandAddTicketForm()}
         >
-          ＋ Create Ticket
+          {this.state.expanded ? '—' : '＋'} Create Ticket
         </button>
         {this.state.expanded && (
           <form>

--- a/src/components/Tickets/CreateTicket.js
+++ b/src/components/Tickets/CreateTicket.js
@@ -11,7 +11,12 @@ class CreateTicket extends PureComponent {
     phaseValue: '',
     projectValue: '',
     hasSelectedProject: false,
-    hasSelectedPhase: false
+    hasSelectedPhase: false,
+    hasSummary: false,
+    hasBudgetHours: false,
+    hasDescription: false,
+    summary: '',
+    budget: '',
   }
 
   componentDidMount = () => {
@@ -92,7 +97,9 @@ class CreateTicket extends PureComponent {
             {this.state.ticketType === 'project' ? (
               <React.Fragment>
                 <div>
+                  <label htmlFor="projects">Project</label>
                   <Autocomplete
+                    id="projects"
                     items={this.state.projects}
                     getItemValue={item => item.name}
                     shouldItemRender={(item, value) => item.name.toLowerCase().indexOf(value.toLowerCase()) > -1}
@@ -113,26 +120,48 @@ class CreateTicket extends PureComponent {
                 </div>
                 <div>
                   {this.state.hasSelectedProject && (
-                    <Autocomplete
-                      items={this.state.phases}
-                      getItemValue={item => item.path}
-                      shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
-                      renderItem={(item, highlighted) =>
-                        <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
-                          {item.path}
-                        </div>
-                      }
-                      value={this.state.phaseValue}
-                      onChange={e => this.setState({ phaseValue: e.target.value })}
-                      onSelect={value => {
-                        this.setState({
-                          phaseValue: value,
-                          hasSelectedPhase: true
-                        })
-                      }}
-                    />
+                    <React.Fragment>
+                      <label htmlFor="phases">Phase</label>
+                      <Autocomplete
+                        id="phases"
+                        items={this.state.phases}
+                        getItemValue={item => item.path}
+                        shouldItemRender={(item, value) => item.path.toLowerCase().indexOf(value.toLowerCase()) > -1}
+                        renderItem={(item, highlighted) =>
+                          <div key={item.id} style={{ backgroundColor: highlighted ? '#eee' : 'transparent'}}>
+                            {item.path}
+                          </div>
+                        }
+                        value={this.state.phaseValue}
+                        onChange={e => this.setState({ phaseValue: e.target.value })}
+                        onSelect={value => {
+                          this.setState({
+                            phaseValue: value,
+                            hasSelectedPhase: true
+                          })
+                        }}
+                      />
+                    </React.Fragment>
                   )}
                 </div>
+                  {this.state.hasSelectedPhase && (
+                    <div>
+                      <label htmlFor="summary">Summary</label>
+                      <input type="text" id="summary" onChange={() => this.setState({ hasSummary: true })}></input>
+                    </div>
+                  )}
+                  {this.state.hasSummary && (
+                    <div>
+                      <label htmlFor="budget-hours">Budget Hours</label>
+                      <input type="number" id="budget-hours" onChange={() => this.setState({ hasBudgetHours: true })}></input>
+                    </div>
+                  )}
+                  {this.state.hasBudgetHours && (
+                    <div>
+                      <label htmlFor="description">Description</label>
+                      <textarea id="description" onChange={() => this.setState({ hasDescription: true })}></textarea>
+                    </div>
+                  )}
               </React.Fragment>
             ) : (
               console.log('service')

--- a/src/components/Tickets/index.js
+++ b/src/components/Tickets/index.js
@@ -17,6 +17,7 @@ class Tickets extends Component {
 
     this.state = {
       expanded: '',
+      selectedProject: {}
     }
 
     this.addProject = this.addProject.bind(this);
@@ -64,6 +65,12 @@ class Tickets extends Component {
     this.props.dispatch(search(nextQuery));
   }
 
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.tickets.query !== this.props.tickets.query) {
+      this.setSelectedProject();
+    }
+  }
+
   expand(id) {
     const isExpanded = this.state.expanded === id;
     let nextState = id;
@@ -72,6 +79,14 @@ class Tickets extends Component {
     }
 
     this.setState({ expanded: nextState });
+  }
+
+  setSelectedProject = () => {
+    const selectedProject = this.props.tickets.query;
+
+    this.setState({
+      selectedProject
+    });
   }
 
   render() {
@@ -120,10 +135,11 @@ class Tickets extends Component {
                 }, true)}
               />
             </div>
-            <CreateTicket
-              projects={this.projects()}
-              tickets={this.props.tickets.flattened}
-            />
+              <CreateTicket
+                projects={this.projects()}
+                tickets={this.props.tickets.flattened}
+                selectedProject={this.state.selectedProject}
+              />
             {this.props.tickets.flattened.length > 0 && (
               <Table
                 id="table-search-tickets"

--- a/src/components/Tickets/index.js
+++ b/src/components/Tickets/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import sortBy from 'sort-by';
 import { connect } from 'react-redux';
 import { search } from '../../actions/tickets';
+import CreateTicket from './CreateTicket';
 
 class Tickets extends Component {
   constructor() {
@@ -119,6 +120,7 @@ class Tickets extends Component {
                 }, true)}
               />
             </div>
+            <CreateTicket />
             {this.props.tickets.flattened.length > 0 && (
               <Table
                 id="table-search-tickets"

--- a/src/components/Tickets/index.js
+++ b/src/components/Tickets/index.js
@@ -120,7 +120,10 @@ class Tickets extends Component {
                 }, true)}
               />
             </div>
-            <CreateTicket />
+            <CreateTicket
+              projects={this.projects()}
+              tickets={this.props.tickets.flattened}
+            />
             {this.props.tickets.flattened.length > 0 && (
               <Table
                 id="table-search-tickets"

--- a/src/helpers/cw.js
+++ b/src/helpers/cw.js
@@ -62,6 +62,14 @@ export const updateTicketStatus = params => {
   }).then(checkStatus).then(parseJSON);
 };
 
+export const createTicket = params => {
+  return fetch(`${process.env.REACT_APP_API_URL}/v1/ticket`, {
+    headers,
+    method: 'POST',
+    body: JSON.stringify(params),
+  }).then(checkStatus).then(parseJSON);
+};
+
 export const createWorkplan = params => {
   const headers = {
     Authorization: `Basic ${process.env.REACT_APP_API_KEY}`,

--- a/src/index.css
+++ b/src/index.css
@@ -343,14 +343,20 @@ td.col--budget:not(:empty)::after {
 .create-ticket-form input,
 .create-ticket-form select {
   height: 40px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 .create-ticket-form label {
-  margin-top: 10px;
+  margin-top: 15px;
 }
 
 .create-ticket-form input[type="number"] {
   max-width: 80px;
+}
+
+.create-ticket-form .btn-submit {
+  margin-top: 15px;
 }
 
 .autocomplete-field div {
@@ -360,6 +366,11 @@ td.col--budget:not(:empty)::after {
 
 .autocomplete-field div input {
   width: 100%;
+  padding-left: 15px;
+  padding-right: 10px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .autocomplete-field input[aria-expanded="true"] + div {
@@ -379,4 +390,3 @@ td.col--budget:not(:empty)::after {
 .autocomplete-field input[aria-expanded="true"] + div div:focus {
   background-color: #f5f5f5 !important;
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -330,38 +330,36 @@ td.col--budget:not(:empty)::after {
   }
 }
 
-.create-ticket-form {
-  max-width: 400px;
-  margin: 0 0 40px 15px;
-}
-
-.create-ticket-form button {
-  margin-bottom: 20px;
-  font-size: 16px;
-}
-
-.create-ticket-form input,
-.create-ticket-form select {
+.ticket-modal input,
+.ticket-modal select {
   height: 40px;
   border: 1px solid #ccc;
   border-radius: 4px;
 }
 
-.create-ticket-form label {
+.ticket-modal label {
   margin-top: 15px;
 }
 
-.create-ticket-form input[type="number"] {
+.ticket-modal input[type="number"] {
   max-width: 80px;
 }
 
-.create-ticket-form .btn-submit {
+.ticket-modal .btn-submit {
   margin-top: 15px;
 }
 
+.ticket-modal {
+  max-width: 700px;
+  width: 100%;
+  left: 50%;
+  height: 700px;
+  transform: translateX(-50%);
+}
+
+.ticket-modal input,
 .autocomplete-field div {
   width: 100%;
-  max-width: 400px;
 }
 
 .autocomplete-field div input {

--- a/src/index.css
+++ b/src/index.css
@@ -339,3 +339,44 @@ td.col--budget:not(:empty)::after {
   margin-bottom: 20px;
   font-size: 16px;
 }
+
+.create-ticket-form input,
+.create-ticket-form select {
+  height: 40px;
+}
+
+.create-ticket-form label {
+  margin-top: 10px;
+}
+
+.create-ticket-form input[type="number"] {
+  max-width: 80px;
+}
+
+.autocomplete-field div {
+  width: 100%;
+  max-width: 400px;
+}
+
+.autocomplete-field div input {
+  width: 100%;
+}
+
+.autocomplete-field input[aria-expanded="true"] + div {
+  background: white !important;
+  font-size: 14px !important;
+  border: 1px solid #ccc;
+}
+
+.autocomplete-field input[aria-expanded="true"] + div div {
+  height: 35px;
+  line-height: 35px;
+  padding: 0 20px;
+  cursor: pointer;
+}
+
+.autocomplete-field input[aria-expanded="true"] + div div:hover,
+.autocomplete-field input[aria-expanded="true"] + div div:focus {
+  background-color: #f5f5f5 !important;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -390,6 +390,7 @@ td.col--budget:not(:empty)::after {
 }
 
 .autocomplete-field input[aria-expanded="true"] + div {
+  /* override react-autocomplete */
   background: white !important;
   font-size: 14px !important;
   border: 1px solid #ccc;
@@ -404,5 +405,6 @@ td.col--budget:not(:empty)::after {
 
 .autocomplete-field input[aria-expanded="true"] + div div:hover,
 .autocomplete-field input[aria-expanded="true"] + div div:focus {
+  /* override react-autocomplete */
   background-color: #f5f5f5 !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -330,6 +330,12 @@ td.col--budget:not(:empty)::after {
   }
 }
 
+.btn-expand {
+  position: absolute;
+  top: 100px;
+  right: 30px;
+}
+
 .ticket-modal input,
 .ticket-modal select {
   height: 40px;

--- a/src/index.css
+++ b/src/index.css
@@ -329,3 +329,13 @@ td.col--budget:not(:empty)::after {
     overflow-wrap: break-word;
   }
 }
+
+.create-ticket-form {
+  max-width: 400px;
+  margin: 0 0 40px 15px;
+}
+
+.create-ticket-form button {
+  margin-bottom: 20px;
+  font-size: 16px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -353,19 +353,31 @@ td.col--budget:not(:empty)::after {
 
 .ticket-modal .btn-submit {
   margin-top: 15px;
+  margin-bottom: 20px;
 }
 
 .ticket-modal {
   max-width: 700px;
   width: 100%;
   left: 50%;
-  height: 700px;
-  transform: translateX(-50%);
+  height: 850px;
+  transform: translate(-50%, -30px);
+}
+
+.ticket-modal .ReactModal__Content {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
 }
 
 .ticket-modal input,
 .autocomplete-field div {
   width: 100%;
+}
+
+.autocomplete-field > div > div {
+  /* override react-autocomplete */
+  left: 50% !important;
+  transform: translate(-50%, 20px) !important;
+  max-width: 500px;
 }
 
 .autocomplete-field div input {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,6 +3481,11 @@ dom-helpers@^3.4.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
+dom-scroll-into-view@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz#32abb92f0d8feca6215162aef43e4b449ab8d99c"
+  integrity sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw=
+
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -8397,6 +8402,14 @@ react-app-polyfill@^1.0.1:
     raf "3.4.1"
     regenerator-runtime "0.13.2"
     whatwg-fetch "3.0.0"
+
+react-autocomplete@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/react-autocomplete/-/react-autocomplete-1.8.1.tgz#ebbbc400006aa91ad538b2d14727b9e7e5d06310"
+  integrity sha1-67vEAABqqRrVOLLRRye55+XQYxA=
+  dependencies:
+    dom-scroll-into-view "1.0.1"
+    prop-types "^15.5.10"
 
 react-beautiful-dnd@^11.0.4:
   version "11.0.4"


### PR DESCRIPTION
### When reviewing, I strongly suggest reviewing as a whole rather than commit-by-commit. Lots of stuff was added and then deleted or heavily modified in later commits

#### This feature as a whole is still a WIP, so it's not going into master yet. I want to improve styling, clean up some code, improve some function and variable names, and look into potential errors and handle them.

Now you can create a new ticket from the dashboard. At the moment, only Projects tickets can be created. When you select a project from the active projects dropdown, a button will appear to the side allowing you to create a new ticket. Clicking that opens a modal with the fields needed for a ticket. It auto-selects the project you clicked in the active sidebar, and the phase field is an autocomplete dropdown with fuzzy searching that is limited to the phases of the selected project. Each field only becomes visible once the previous field has been completed.

Must be merged with https://github.com/sdinteractive/UnwiseConnect-API/pull/1

<img width="1013" alt="Screen Shot 2021-01-05 at 3 09 56 PM" src="https://user-images.githubusercontent.com/32035286/103694022-3b98e100-4f68-11eb-8bb5-1e303cfe4c57.png">
